### PR TITLE
Address deprecation warning in HelicsEndpoint.n_pending_messages

### DIFF
--- a/helics/capi.py
+++ b/helics/capi.py
@@ -1175,7 +1175,7 @@ class HelicsEndpoint(_HelicsCHandle):
     @property
     def n_pending_messages(self) -> int:
         """Returns the number of pending receives for endpoint."""
-        return helicsEndpointPendingMessages(self)
+        return helicsEndpointPendingMessagesCount(self)
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
The `HelicsEndpoint.n_pending_messages` property uses the deprecated API function `helicsEndpointPendingMessages()`. This replaces that call with a call to `helicsEndpointPendingMessagesCount()` as recommended by the deprecation warning.