### PR TITLE
BUG helicsMessageGetBytes truncates at NUL.

### DIFF
--- a/helics/capi.py
+++ b/helics/capi.py
@@ -5829,7 +5829,7 @@ def helicsMessageGetBytes(message: HelicsMessage) -> bytes:
     f(message.handle, data, maxMessageLen, actualSize, err)
     if err.error_code != 0:
         raise HelicsException("[" + str(err.error_code) + "] " + ffi.string(err.message).decode())
-    return ffi.string(data, maxlen=actualSize[0])
+    return ffi.buffer(data, actualSize[0])[:]
 
 
 def helicsMessageGetRawDataPointer(message: HelicsMessage) -> pointer:


### PR DESCRIPTION
helicsMessageGetBytes truncates the received data at the first
occurrence of NUL. This is because ffi.string(cdata, maxlen) scans maxlen bytes for the
first occurrence of NUL. Contrary to ffi.string, ffi.buffer(cdata, length) assumes cdata is length.