### PR TITLE
Correct copy-paste error for helicsTranslatorGetName

### DIFF
--- a/helics/capi.py
+++ b/helics/capi.py
@@ -7269,7 +7269,7 @@ def helicsTranslatorGetName(translator: HelicsTranslator) -> str:
 
     **Returns**: A string with the name of the translator.
     """
-    f = loadSym("helicsPublicationGetName")
+    f = loadSym("helicsTranslatorGetName")
     result = f(translator.handle)
     return ffi.string(result).decode()
 


### PR DESCRIPTION
Small patch to correct copy-paste error for `helicsTranslatorGetName()`