### PR TITLE
Respect PYHELICS_INSTALL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -182,7 +182,7 @@ HELICS_VERSION = re.findall(r"(?:(\d+\.(?:\d+\.)*\d+))", PYHELICS_VERSION)[0]
 CURRENT_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
 
 HELICS_SOURCE = os.path.join(CURRENT_DIRECTORY, "./_source")
-PYHELICS_INSTALL = os.environ.get("PYHELICS_INSTALL") if os.environ.get("PYHELICS_INSTALL") else os.path.join(CURRENT_DIRECTORY, "./helics/install")
+PYHELICS_INSTALL = os.environ.get("PYHELICS_INSTALL", os.path.join(CURRENT_DIRECTORY, "./helics/install")
 
 DOWNLOAD_URL = "https://github.com/GMLC-TDC/HELICS/releases/download/v{version}/Helics-v{version}-source.tar.gz".format(version=HELICS_VERSION)
 

--- a/setup.py
+++ b/setup.py
@@ -182,7 +182,7 @@ HELICS_VERSION = re.findall(r"(?:(\d+\.(?:\d+\.)*\d+))", PYHELICS_VERSION)[0]
 CURRENT_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
 
 HELICS_SOURCE = os.path.join(CURRENT_DIRECTORY, "./_source")
-PYHELICS_INSTALL = os.environget("PYHELICS_INSTALL") if os.environget("PYHELICS_INSTALL") else os.path.join(CURRENT_DIRECTORY, "./helics/install")
+PYHELICS_INSTALL = os.environ.get("PYHELICS_INSTALL") if os.environ.get("PYHELICS_INSTALL") else os.path.join(CURRENT_DIRECTORY, "./helics/install")
 
 DOWNLOAD_URL = "https://github.com/GMLC-TDC/HELICS/releases/download/v{version}/Helics-v{version}-source.tar.gz".format(version=HELICS_VERSION)
 

--- a/setup.py
+++ b/setup.py
@@ -182,7 +182,7 @@ HELICS_VERSION = re.findall(r"(?:(\d+\.(?:\d+\.)*\d+))", PYHELICS_VERSION)[0]
 CURRENT_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
 
 HELICS_SOURCE = os.path.join(CURRENT_DIRECTORY, "./_source")
-PYHELICS_INSTALL = os.env.get("PYHELICS_INSTALL") if os.env.get("PYHELICS_INSTALL") else os.path.join(CURRENT_DIRECTORY, "./helics/install")
+PYHELICS_INSTALL = os.environget("PYHELICS_INSTALL") if os.environget("PYHELICS_INSTALL") else os.path.join(CURRENT_DIRECTORY, "./helics/install")
 
 DOWNLOAD_URL = "https://github.com/GMLC-TDC/HELICS/releases/download/v{version}/Helics-v{version}-source.tar.gz".format(version=HELICS_VERSION)
 

--- a/setup.py
+++ b/setup.py
@@ -182,7 +182,7 @@ HELICS_VERSION = re.findall(r"(?:(\d+\.(?:\d+\.)*\d+))", PYHELICS_VERSION)[0]
 CURRENT_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
 
 HELICS_SOURCE = os.path.join(CURRENT_DIRECTORY, "./_source")
-PYHELICS_INSTALL = os.path.join(CURRENT_DIRECTORY, "./helics/install")
+PYHELICS_INSTALL = os.env.get("PYHELICS_INSTALL") if os.env.get("PYHELICS_INSTALL") else os.path.join(CURRENT_DIRECTORY, "./helics/install")
 
 DOWNLOAD_URL = "https://github.com/GMLC-TDC/HELICS/releases/download/v{version}/Helics-v{version}-source.tar.gz".format(version=HELICS_VERSION)
 

--- a/setup.py
+++ b/setup.py
@@ -182,7 +182,7 @@ HELICS_VERSION = re.findall(r"(?:(\d+\.(?:\d+\.)*\d+))", PYHELICS_VERSION)[0]
 CURRENT_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
 
 HELICS_SOURCE = os.path.join(CURRENT_DIRECTORY, "./_source")
-PYHELICS_INSTALL = os.environ.get("PYHELICS_INSTALL", os.path.join(CURRENT_DIRECTORY, "./helics/install")
+PYHELICS_INSTALL = os.environ.get("PYHELICS_INSTALL", os.path.join(CURRENT_DIRECTORY, "./helics/install"))
 
 DOWNLOAD_URL = "https://github.com/GMLC-TDC/HELICS/releases/download/v{version}/Helics-v{version}-source.tar.gz".format(version=HELICS_VERSION)
 


### PR DESCRIPTION
## Problem

When setting the PYHELICS_INSTALL environment variable, the setup.py will still attempt to download or build the HELICS binaries. 

## Expected Outcome

When setting PYHELICS_INSTALL, the setup.py should respect this and not proceed with downloading or building HELICS into `./helics/`. 

## Solution

Respect the PYHELICS_INSTALL environment variable as described in https://python.helics.org/installation/ by setting the PYHELICS_INSTALL variable in setup.py to the environment variable `PYHELICS_INSTALL` if set, otherwise set to a default path of `./helics` as previously set in the setup.py before. 
