### PR TITLE
Remove python2 support

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,19 +17,15 @@ jobs:
           - os: macOS-latest
             target: macosx_10_14_universal2.macosx_10_14_x86_64.macosx_11_0_arm64
             python3-version: "3.8"
-            python2-version: "2.7"
           - os: ubuntu-latest
             target: manylinux2010_x86_64
             python3-version: "3.8"
-            python2-version: "2.7"
           - os: windows-latest
             target: win_amd64
             python3-version: "3.8"
-            python2-version: "2.7"
           - os: windows-latest
             target: win32
             python3-version: "3.8"
-            python2-version: "2.7"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -51,25 +47,6 @@ jobs:
           python setup.py bdist_wheel --plat-name=${{ matrix.target }}
           python scripts/cleanup_bdist.py ${{ matrix.target }}
 
-      # Steps to build Python 2 wheels
-      - name: Set up Python2
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python2-version }}
-
-      - name: Install python2 dependencies
-        run: |
-          python -m pip install -U pip install wheel setuptools cffi strip-hints pathlib2
-
-      - name: Build python2 wheel
-        if: ${{ matrix.target }} == win_amd32
-        run: |
-          strip-hints helics/capi.py > tmp
-          rm helics/capi.py
-          mv tmp helics/capi.py
-          python setup.py bdist_wheel --plat-name=${{ matrix.target }}
-          python scripts/cleanup_bdist.py ${{ matrix.target }}
-      # End steps to build Python 2 wheels
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/helics/capi.py
+++ b/helics/capi.py
@@ -986,7 +986,7 @@ class _FilterOptionAccessor(_HelicsCHandle):
 
 class HelicsFilter(_HelicsCHandle):
     def __init__(self, handle, cleanup=True):
-        super(HelicsFilter, self).__init__(handle, cleanup=cleanup)
+        super().__init__(handle, cleanup=cleanup)
         self.option = _FilterOptionAccessor(self.handle, cleanup=False)
 
     def __repr__(self):
@@ -1060,7 +1060,7 @@ class HelicsCloningFilter(HelicsFilter):
 
 class HelicsTranslator(_HelicsCHandle):
     def __init__(self, handle, cleanup=True):
-        super(HelicsTranslator, self).__init__(handle, cleanup=cleanup)
+        super().__init__(handle, cleanup=cleanup)
 
 
 class HelicsCore(_HelicsCHandle):
@@ -1365,7 +1365,7 @@ class _MessageFlagAccessor(_HelicsCHandle):
 
 class HelicsMessage(_HelicsCHandle):
     def __init__(self, handle, cleanup=True):
-        super(HelicsMessage, self).__init__(handle, cleanup=cleanup)
+        super().__init__(handle, cleanup=cleanup)
         self.flag = _MessageFlagAccessor(self.handle, cleanup=False)
 
     def __repr__(self):
@@ -1608,8 +1608,7 @@ class _FederateInfoPropertyAccessor(_HelicsCHandle):
 
 class HelicsFederateInfo(_HelicsCHandle):
     def __init__(self, handle, cleanup=True):
-        # Python2 compatible super
-        super(HelicsFederateInfo, self).__init__(handle, cleanup)
+        super().__init__(handle, cleanup)
 
         self.property = _FederateInfoPropertyAccessor(self.handle, cleanup=False)
         self.flag = _FederateInfoFlagAccessor(self.handle, cleanup=False)
@@ -1825,8 +1824,7 @@ class _FederatePropertyAccessor(_HelicsCHandle):
 
 class HelicsFederate(_HelicsCHandle):
     def __init__(self, handle, cleanup=True):
-        # Python2 compatible super
-        super(HelicsFederate, self).__init__(handle, cleanup)
+        super().__init__(handle, cleanup)
 
         self._exec_async_iterate = False
         self.property = _FederatePropertyAccessor(self.handle, cleanup=False)
@@ -2374,7 +2372,7 @@ class _InputOptionAccessor(_HelicsCHandle):
 
 class HelicsInput(_HelicsCHandle):
     def __init__(self, handle):
-        super(HelicsInput, self).__init__(handle, cleanup=False)
+        super().__init__(handle, cleanup=False)
         self.option = _InputOptionAccessor(self.handle, cleanup=False)
 
     def __repr__(self):
@@ -2579,7 +2577,7 @@ class HelicsInput(_HelicsCHandle):
 
 class HelicsPublication(_HelicsCHandle):
     def __init__(self, handle):
-        super(HelicsPublication, self).__init__(handle, cleanup=False)
+        super().__init__(handle, cleanup=False)
         self.option = _PublicationOptionAccessor(self.handle, cleanup=False)
 
     def __repr__(self):
@@ -2669,7 +2667,7 @@ class HelicsPublication(_HelicsCHandle):
 
 class HelicsValueFederate(HelicsFederate):
     def __init__(self, handle):
-        super(HelicsValueFederate, self).__init__(handle)
+        super().__init__(handle)
 
         for i in range(0, self.n_publications):
             pub = self.get_publication_by_index(i)
@@ -2858,7 +2856,7 @@ class HelicsValueFederate(HelicsFederate):
 
 class HelicsMessageFederate(HelicsFederate):
     def __init__(self, handle):
-        super(HelicsMessageFederate, self).__init__(handle)
+        super().__init__(handle)
 
         for i in range(0, self.n_endpoints):
             end = self.get_endpoint_by_index(i)

--- a/setup.py
+++ b/setup.py
@@ -562,10 +562,7 @@ if sys.version_info < (3, 4):
 class HelicsBdistWheel(bdist_wheel):
     def get_tag(self):
         rv = bdist_wheel.get_tag(self)
-        if platform.python_version().startswith("2"):
-            return ("py2", "none") + rv[2:]
-        else:
-            return ("py3", "none") + rv[2:]
+        return ("py3", "none") + rv[2:]
 
 
 cmdclass = {
@@ -615,7 +612,6 @@ setup(
         "Operating System :: POSIX",
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
@@ -626,7 +622,7 @@ setup(
     ],
     project_urls={"Issue Tracker": "https://github.com/GMLC-TDC/pyhelics/issues"},
     keywords=["helics", "co-simulation"],
-    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*",
+    python_requires=">=3.6",
     install_requires=install_requires,
     extras_require={
         "cli": install_requires + helics_cli_install_requires,


### PR DESCRIPTION
Removes Python 2 jobs from release builds, required to get the job passing so new pyhelics 3.5 wheels can be published. Removes python2 specific code from setup.py, and cleans up some older Python 2 syntax for super().

Resolves #73