### PR TITLE
Switch to deployment environment and OIDC trusted publishing, and update upload/download artifact actions to v4

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -102,6 +102,11 @@ jobs:
   publish-helics:
     needs: [build-wheels, build-sdist]
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/helics
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
       - name: Get the built packages
         uses: actions/download-artifact@v4
@@ -111,7 +116,7 @@ jobs:
 
       - name: Publish package to TestPyPI
         if: startsWith(github.ref, 'refs/tags/')
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_PASSWORD }}
@@ -119,10 +124,7 @@ jobs:
 
       - name: Publish package to PyPI
         if: startsWith(github.ref, 'refs/tags/')
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_PASSWORD }}
+        uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: GitHub Release
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -71,9 +71,9 @@ jobs:
           python scripts/cleanup_bdist.py ${{ matrix.target }}
       # End steps to build Python 2 wheels
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: python-dist
+          name: python-dist-${{ matrix.target }}
           path: dist/*
 
   build-sdist:
@@ -94,9 +94,9 @@ jobs:
           python setup.py sdist
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: python-dist
+          name: python-sdist
           path: dist/*
 
   publish-helics:
@@ -104,9 +104,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get the built packages
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
-          name: python-dist
+          merge-multiple: true
           path: dist
 
       - name: Publish package to TestPyPI


### PR DESCRIPTION
Use GitHub deployment environments and OIDC trusted publishing for upload wheels to PyPI.
Update the upload and download artifact GitHub actions to v4.