### PR TITLE
Remove repr in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,4 +8,3 @@ def run_around_tests():
     yield
     h.helicsCleanupLibrary()
     h.helicsCloseLibrary()
-    h.helicsCloseLibrary()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+import pytest
+import helics as h
+
+
+@pytest.fixture(autouse=True)
+def run_around_tests():
+    yield
+    h.helicsCleanupLibrary()
+    h.helicsCloseLibrary()
+    h.helicsCloseLibrary()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,18 +1,10 @@
 # -*- coding: utf-8 -*-
-import os
-import sys
-
-CURRENT_DIRECTORY = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
-
-sys.path.append(CURRENT_DIRECTORY)
-sys.path.append(os.path.dirname(CURRENT_DIRECTORY))
-
 import time
 import pytest
 import pytest as pt
 import helics as h
 
-from test_init import createBroker, createValueFederate, destroyFederate, destroyBroker
+from .utils import assert_attributes
 
 
 def test_misc_functions_api():
@@ -41,11 +33,9 @@ def test_broker_api():
     h.helicsBrokerDisconnect(broker2)
     # h.helicsBrokerFree(broker1)
     # h.helicsBrokerFree(broker2)
-    h.helicsCloseLibrary()
 
 
 def test_core_api():
-
     core1 = h.helicsCreateCore("inproc", "core1", "--autobroker")
     assert h.helicsCoreIsValid(core1) is True
     core2 = h.helicsCoreClone(core1)
@@ -53,9 +43,13 @@ def test_core_api():
 
     assert h.helicsCoreIsConnected(core1) == 0
 
-    sourceFilter1 = h.helicsCoreRegisterFilter(core1, h.HELICS_FILTER_TYPE_DELAY, "core1SourceFilter")
+    sourceFilter1 = h.helicsCoreRegisterFilter(
+        core1, h.HELICS_FILTER_TYPE_DELAY, "core1SourceFilter"
+    )
     h.helicsFilterAddSourceTarget(sourceFilter1, "ep1")
-    destinationFilter1 = h.helicsCoreRegisterFilter(core1, h.HELICS_FILTER_TYPE_DELAY, "core1DestinationFilter")
+    destinationFilter1 = h.helicsCoreRegisterFilter(
+        core1, h.HELICS_FILTER_TYPE_DELAY, "core1DestinationFilter"
+    )
     h.helicsFilterAddDestinationTarget(destinationFilter1, "ep2")
     cloningFilter1 = h.helicsCoreRegisterCloningFilter(core1, "ep3")
     h.helicsFilterRemoveDeliveryEndpoint(cloningFilter1, "ep3")
@@ -65,7 +59,6 @@ def test_core_api():
     h.helicsCoreDisconnect(core2)
     # h.helicsCoreFree(core1)
     # h.helicsCoreFree(core2)
-    h.helicsCloseLibrary()
 
 
 class UserData(object):
@@ -73,20 +66,25 @@ class UserData(object):
         self.x = x
 
 
-@h.ffi.callback("void logger(int loglevel, const char* identifier, const char* message, void* userData)")
+@h.ffi.callback(
+    "void logger(int loglevel, const char* identifier, const char* message, void* userData)"
+)
 def logger(loglevel: int, identifier: str, message: str, userData: object):
     userData = h.ffi.from_handle(userData)
-    print(f"{loglevel}, {h.ffi.string(identifier).decode()}, {h.ffi.string(message).decode()}, {userData}")
+    print(
+        f"{loglevel}, {h.ffi.string(identifier).decode()}, {h.ffi.string(message).decode()}, {userData}"
+    )
     userData.x += 1
 
 
 def test_logging_api():
-
     fi = h.helicsCreateFederateInfo()
     broker = h.helicsCreateBroker("zmq", "broker", "--federates 1")
     h.helicsFederateInfoSetCoreInitString(fi, "--federates 1")
 
-    h.helicsFederateInfoSetIntegerProperty(fi, h.HELICS_PROPERTY_INT_LOG_LEVEL, h.HELICS_LOG_LEVEL_TIMING)
+    h.helicsFederateInfoSetIntegerProperty(
+        fi, h.HELICS_PROPERTY_INT_LOG_LEVEL, h.HELICS_LOG_LEVEL_TIMING
+    )
 
     fed = h.helicsCreateValueFederate("test1", fi)
 
@@ -118,9 +116,6 @@ def test_logging_api():
     h.helicsBrokerDisconnect(broker)
     # h.helicsBrokerFree(broker)
 
-    h.helicsCleanupLibrary()
-    h.helicsCloseLibrary()
-
 
 @pt.mark.skip()
 def test_misc_api():
@@ -130,10 +125,16 @@ def test_misc_api():
     h.helicsFederateInfoSetCoreType(fedInfo1, 3)
     h.helicsFederateInfoSetCoreTypeFromString(fedInfo1, "zmq")
     h.helicsFederateInfoSetFlagOption(fedInfo1, 1, True)
-    h.helicsFederateInfoSetTimeProperty(fedInfo1, h.HELICS_PROPERTY_TIME_INPUT_DELAY, 1.0)
+    h.helicsFederateInfoSetTimeProperty(
+        fedInfo1, h.HELICS_PROPERTY_TIME_INPUT_DELAY, 1.0
+    )
     h.helicsFederateInfoSetIntegerProperty(fedInfo1, h.HELICS_PROPERTY_INT_LOG_LEVEL, 1)
-    h.helicsFederateInfoSetIntegerProperty(fedInfo1, h.HELICS_PROPERTY_INT_MAX_ITERATIONS, 100)
-    h.helicsFederateInfoSetTimeProperty(fedInfo1, h.HELICS_PROPERTY_TIME_OUTPUT_DELAY, 1.0)
+    h.helicsFederateInfoSetIntegerProperty(
+        fedInfo1, h.HELICS_PROPERTY_INT_MAX_ITERATIONS, 100
+    )
+    h.helicsFederateInfoSetTimeProperty(
+        fedInfo1, h.HELICS_PROPERTY_TIME_OUTPUT_DELAY, 1.0
+    )
     h.helicsFederateInfoSetTimeProperty(fedInfo1, h.HELICS_PROPERTY_TIME_PERIOD, 1.0)
     h.helicsFederateInfoSetTimeProperty(fedInfo1, h.HELICS_PROPERTY_TIME_DELTA, 1.0)
     h.helicsFederateInfoSetTimeProperty(fedInfo1, h.HELICS_PROPERTY_TIME_OFFSET, 0.1)
@@ -144,7 +145,9 @@ def test_misc_api():
     coreInitString = "--federates 1"
     h.helicsFederateInfoSetCoreInitString(fedInfo2, coreInitString)
     h.helicsFederateInfoSetCoreTypeFromString(fedInfo2, "zmq")
-    h.helicsFederateInfoSetIntegerProperty(fedInfo2, h.HELICS_PROPERTY_INT_LOG_LEVEL, h.HELICS_LOG_LEVEL_WARNING)
+    h.helicsFederateInfoSetIntegerProperty(
+        fedInfo2, h.HELICS_PROPERTY_INT_LOG_LEVEL, h.HELICS_LOG_LEVEL_WARNING
+    )
     h.helicsFederateInfoSetTimeProperty(fedInfo2, h.HELICS_PROPERTY_TIME_DELTA, 1.0)
     fed1 = h.helicsCreateCombinationFederate("fed1", fedInfo2)
     fed2 = h.helicsFederateClone(fed1)
@@ -152,24 +155,32 @@ def test_misc_api():
     h.helicsFederateSetFlagOption(fed2, 1, False)
 
     h.helicsFederateSetTimeProperty(fed2, h.HELICS_PROPERTY_TIME_INPUT_DELAY, 1.0)
-    h.helicsFederateSetIntegerProperty(fed1, h.HELICS_PROPERTY_INT_LOG_LEVEL, h.HELICS_LOG_LEVEL_WARNING)
+    h.helicsFederateSetIntegerProperty(
+        fed1, h.HELICS_PROPERTY_INT_LOG_LEVEL, h.HELICS_LOG_LEVEL_WARNING
+    )
     h.helicsFederateSetIntegerProperty(fed2, h.HELICS_PROPERTY_INT_MAX_ITERATIONS, 100)
     h.helicsFederateSetTimeProperty(fed2, h.HELICS_PROPERTY_TIME_OUTPUT_DELAY, 1.0)
     h.helicsFederateSetTimeProperty(fed2, h.HELICS_PROPERTY_TIME_PERIOD, 0.0)
     h.helicsFederateSetTimeProperty(fed2, h.HELICS_PROPERTY_TIME_DELTA, 1.0)
 
     _ = h.helicsFederateRegisterCloningFilter(fed1, "fed1/Ep1")
-    fed1DestinationFilter = h.helicsFederateRegisterFilter(fed1, h.HELICS_FILTER_TYPE_DELAY, "fed1DestinationFilter")
+    fed1DestinationFilter = h.helicsFederateRegisterFilter(
+        fed1, h.HELICS_FILTER_TYPE_DELAY, "fed1DestinationFilter"
+    )
     h.helicsFilterAddDestinationTarget(fed1DestinationFilter, "Ep2")
 
     ep1 = h.helicsFederateRegisterEndpoint(fed1, "Ep1", "string")
     ep2 = h.helicsFederateRegisterGlobalEndpoint(fed1, "Ep2", "string")
-    pub1 = h.helicsFederateRegisterGlobalPublication(fed1, "pub1", h.HELICS_DATA_TYPE_DOUBLE, "")
+    pub1 = h.helicsFederateRegisterGlobalPublication(
+        fed1, "pub1", h.HELICS_DATA_TYPE_DOUBLE, ""
+    )
     pub2 = h.helicsFederateRegisterGlobalTypePublication(fed1, "pub2", "complex", "")
 
     sub1 = h.helicsFederateRegisterSubscription(fed1, "pub1")
     sub2 = h.helicsFederateRegisterSubscription(fed1, "pub2")
-    pub3 = h.helicsFederateRegisterPublication(fed1, "pub3", h.HELICS_DATA_TYPE_STRING, "")
+    pub3 = h.helicsFederateRegisterPublication(
+        fed1, "pub3", h.HELICS_DATA_TYPE_STRING, ""
+    )
 
     pub1KeyString = h.helicsPublicationGetKey(pub1)
     pub1TypeString = h.helicsPublicationGetType(pub1)
@@ -182,7 +193,9 @@ def test_misc_api():
     assert "pub1" == sub1KeyString
     assert "" == sub1UnitsString
 
-    fed1SourceFilter = h.helicsFederateRegisterFilter(fed1, h.HELICS_FILTER_TYPE_DELAY, "fed1SourceFilter")
+    fed1SourceFilter = h.helicsFederateRegisterFilter(
+        fed1, h.HELICS_FILTER_TYPE_DELAY, "fed1SourceFilter"
+    )
     h.helicsFilterAddSourceTarget(fed1SourceFilter, "Ep2")
     h.helicsFilterAddDestinationTarget(fed1SourceFilter, "fed1/Ep1")
     h.helicsFilterRemoveTarget(fed1SourceFilter, "fed1/Ep1")
@@ -199,21 +212,50 @@ def test_misc_api():
     pub5 = h.helicsFederateRegisterGlobalTypePublication(fed1, "pub5", "boolean", "")
 
     sub5 = h.helicsFederateRegisterSubscription(fed1, "pub5", "")
-    pub6 = h.helicsFederateRegisterGlobalPublication(fed1, "pub6", h.HELICS_DATA_TYPE_VECTOR, "")
+    pub6 = h.helicsFederateRegisterGlobalPublication(
+        fed1, "pub6", h.HELICS_DATA_TYPE_VECTOR, ""
+    )
     sub6 = h.helicsFederateRegisterSubscription(fed1, "pub6", "")
-    pub7 = h.helicsFederateRegisterGlobalPublication(fed1, "pub7", h.HELICS_DATA_TYPE_NAMED_POINT, "")
+    pub7 = h.helicsFederateRegisterGlobalPublication(
+        fed1, "pub7", h.HELICS_DATA_TYPE_NAMED_POINT, ""
+    )
     sub7 = h.helicsFederateRegisterSubscription(fed1, "pub7", "")
 
-    assert """helics.HelicsPublication(name = "pub1", type = "double", units = "", info = "")""" in repr(pub1)
-    assert """helics.HelicsPublication(name = "pub2", type = "complex", units = "", info = "")""" in repr(pub2)
-    assert """helics.HelicsPublication(name = "fed1/pub3", type = "string", units = "", info = "")""" in repr(pub3)
-    assert """helics.HelicsPublication(name = "fed1/pub4", type = "int", units = "", info = "")""" in repr(pub4)
-    assert """helics.HelicsPublication(name = "pub5", type = "boolean", units = "", info = "")""" in repr(pub5)
-    assert """helics.HelicsPublication(name = "pub6", type = "double_vector", units = "", info = "")""" in repr(pub6)
-    assert """helics.HelicsPublication(name = "pub7", type = "named_point", units = "", info = "")""" in repr(pub7)
-    assert (
-        """helics.HelicsInput(name = "_input_18", units = "", injection_units = "", publication_type = "", type = "", target = "pub7", info = "")"""
-        in repr(sub7)
+    for pub in [pub1, pub2, pub3, pub4, pub5, pub6, pub7]:
+        assert isinstance(pub, h.HelicsPublication)
+    assert_attributes(pub1, {"name": "pub1", "type": "double", "units": "", "info": ""})
+    assert_attributes(
+        pub2, {"name": "pub2", "type": "complex", "units": "", "info": ""}
+    )
+    assert_attributes(
+        pub3, {"name": "fed1/pub3", "type": "string", "units": "", "info": ""}
+    )
+    assert_attributes(
+        pub4, {"name": "fed1/pub4", "type": "int", "units": "", "info": ""}
+    )
+    assert_attributes(
+        pub5, {"name": "pub5", "type": "boolean", "units": "", "info": ""}
+    )
+    assert_attributes(
+        pub6, {"name": "pub6", "type": "double_vector", "units": "", "info": ""}
+    )
+    assert_attributes(
+        pub7, {"name": "pub7", "type": "named_point", "units": "", "info": ""}
+    )
+
+    for sub in [sub1, sub2, sub3, sub4, sub5, sub6, sub7]:
+        assert isinstance(sub, h.HelicsInput)
+    assert_attributes(
+        sub7,
+        {
+            "name": "_input_18",
+            "units": "",
+            "injection_units": "",
+            "publication_type": "named_point",
+            "type": "",
+            "target": "pub7",
+            "info": "",
+        },
     )
 
     h.helicsInputSetDefaultBoolean(sub5, False)
@@ -239,11 +281,18 @@ def test_misc_api():
     h.helicsFederateEnterExecutingModeAsync(fed1)
     h.helicsFederateEnterExecutingModeComplete(fed1)
 
-    assert (
-        """helics.HelicsInput(name = "_input_18", units = "", injection_units = "", publication_type = "named_point", type = "", target = "pub7", info = "")"""
-        in repr(sub7)
+    assert_attributes(
+        sub7,
+        {
+            "name": "_input_18",
+            "units": "",
+            "injection_units": "",
+            "publication_type": "named_point",
+            "type": "",
+            "target": "pub7",
+            "info": "",
+        },
     )
-
     mesg1 = h.helicsFederateCreateMessage(fed1)
     h.helicsMessageSetString(mesg1, "Hello")
     h.helicsMessageSetSource(mesg1, "fed1/Ep1")
@@ -365,8 +414,6 @@ def test_misc_api():
 
     # h.helicsBrokerFree(broker3)
 
-    h.helicsCleanupLibrary()
-    h.helicsCloseLibrary()
 
 # Exercise the Endpoint *Bytes* interfaces
 def test_send_endpoint_bytes():
@@ -376,7 +423,9 @@ def test_send_endpoint_bytes():
     coreInitString = "--federates 1"
     h.helicsFederateInfoSetCoreInitString(fedInfo, coreInitString)
     h.helicsFederateInfoSetCoreTypeFromString(fedInfo, "zmq")
-    h.helicsFederateInfoSetIntegerProperty(fedInfo, h.HELICS_PROPERTY_INT_LOG_LEVEL, h.HELICS_LOG_LEVEL_WARNING)
+    h.helicsFederateInfoSetIntegerProperty(
+        fedInfo, h.HELICS_PROPERTY_INT_LOG_LEVEL, h.HELICS_LOG_LEVEL_WARNING
+    )
     h.helicsFederateInfoSetTimeProperty(fedInfo, h.HELICS_PROPERTY_TIME_DELTA, 1.0)
     fed = h.helicsCreateMessageFederate("fed", fedInfo)
 
@@ -387,9 +436,9 @@ def test_send_endpoint_bytes():
 
     h.helicsFederateEnterExecutingMode(fed)
 
-    data1 = b'\0\0Hello,\0\0World!\0\0\0\0'
+    data1 = b"\0\0Hello,\0\0World!\0\0\0\0"
     data2 = bytes(x for x in range(256))
-    data3 = b'\0' * 64
+    data3 = b"\0" * 64
 
     msg = h.helicsFederateCreateMessage(fed)
     h.helicsMessageSetData(msg, data1)
@@ -397,7 +446,7 @@ def test_send_endpoint_bytes():
 
     h.helicsEndpointSendBytesTo(ep1, data2, "fed/Ep2")
 
-    h.helicsEndpointSendBytesToAt(ep1, data3, "fed/Ep2", 1.)
+    h.helicsEndpointSendBytesToAt(ep1, data3, "fed/Ep2", 1.0)
 
     h.helicsFederateRequestNextStep(fed)
 
@@ -430,6 +479,3 @@ def test_send_endpoint_bytes():
     h.helicsFederateDisconnect(fed)
 
     h.helicsBrokerDisconnect(broker)
-
-    h.helicsCleanupLibrary()
-    h.helicsCloseLibrary()

--- a/tests/test_badinputs.py
+++ b/tests/test_badinputs.py
@@ -1,25 +1,22 @@
 # -*- coding: utf-8 -*-
-import os
 import sys
 
-CURRENT_DIRECTORY = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
-
-sys.path.append(CURRENT_DIRECTORY)
-sys.path.append(os.path.dirname(CURRENT_DIRECTORY))
-
-import time
-import pytest
 import helics as h
-
-from test_init import createBroker, createValueFederate, destroyFederate, destroyBroker, createMessageFederate
 import pytest as pt
-import sys
+
+from .utils import (
+    create_broker,
+    create_value_federate,
+    destroy_federate,
+    destroy_broker,
+    create_message_federate,
+)
 
 
 @pt.mark.skipif(sys.platform == "win32", reason="Fails to pass on windows")
 def test_bad_input_message_federate_message():
-    broker = createBroker(1)
-    mFed1, fedinfo = createMessageFederate(1, "test")
+    broker = create_broker(1)
+    mFed1, fedinfo = create_message_federate(1, "test")
 
     ept1 = h.helicsFederateRegisterGlobalEndpoint(mFed1, "ept1", "")
     with pt.raises(h.HelicsException):
@@ -43,15 +40,14 @@ def test_bad_input_message_federate_message():
     with pt.raises(h.HelicsException):
         h.helicsEndpointSendMessage(ept1, mess0)
 
-    destroyFederate(mFed1, fedinfo)
-    destroyBroker(broker)
+    destroy_federate(mFed1, fedinfo)
+    destroy_broker(broker)
 
 
 @pt.mark.skipif(sys.platform == "win32", reason="Fails to pass on windows")
 def test_bad_input_filter_test4():
-
-    broker = createBroker(1)
-    mFed1, fedinfo = createMessageFederate(1, "test")
+    broker = create_broker(1)
+    mFed1, fedinfo = create_message_federate(1, "test")
 
     filt1 = h.helicsFederateRegisterCloningFilter(mFed1, "filt1")
     # @test_throws h.HELICSErrorRegistrationFailure
@@ -74,15 +70,14 @@ def test_bad_input_filter_test4():
         h.helicsFilterSet(filt1, "unknown", 10.0)
     h.helicsFederateDisconnect(mFed1)
 
-    destroyFederate(mFed1, fedinfo)
-    destroyBroker(broker)
+    destroy_federate(mFed1, fedinfo)
+    destroy_broker(broker)
 
 
 @pt.mark.skipif(sys.platform == "win32", reason="Fails to pass on windows")
 def test_bad_input_filter_core_tests():
-
-    broker = createBroker(1)
-    mFed1, fedinfo = createMessageFederate(1, "test")
+    broker = create_broker(1)
+    mFed1, fedinfo = create_message_federate(1, "test")
 
     cr = h.helicsFederateGetCore(mFed1)
 
@@ -95,19 +90,21 @@ def test_bad_input_filter_core_tests():
     h.helicsFederateDisconnect(mFed1)
     h.helicsCoreDestroy(cr)
 
-    destroyFederate(mFed1, fedinfo)
-    destroyBroker(broker)
+    destroy_federate(mFed1, fedinfo)
+    destroy_broker(broker)
 
 
 @pt.mark.skipif(sys.platform == "win32", reason="Fails to pass on windows")
 def test_bad_input_type_publication_2_tests():
-    broker = createBroker(1)
-    vFed1, fedinfo = createValueFederate(1, "test")
+    broker = create_broker(1)
+    vFed1, fedinfo = create_value_federate(1, "test")
 
     pubid = h.helicsFederateRegisterGlobalTypePublication(vFed1, "pub1", "string", "")
     with pt.raises(h.HelicsException):
         # @test_throws h.HELICSErrorRegistrationFailure
-        pubid2 = h.helicsFederateRegisterGlobalTypePublication(vFed1, "pub1", "string", "")
+        pubid2 = h.helicsFederateRegisterGlobalTypePublication(
+            vFed1, "pub1", "string", ""
+        )
 
     with pt.raises(h.HelicsException):
         # @test_throws h.HELICSErrorInvalidArgument
@@ -126,7 +123,9 @@ def test_bad_input_type_publication_2_tests():
 
     h.helicsFederateSetTimeProperty(vFed1, h.HELICS_PROPERTY_TIME_PERIOD, 1.0)
 
-    h.helicsFederateEnterExecutingModeIterativeAsync(vFed1, h.HELICS_ITERATION_REQUEST_NO_ITERATION)
+    h.helicsFederateEnterExecutingModeIterativeAsync(
+        vFed1, h.HELICS_ITERATION_REQUEST_NO_ITERATION
+    )
     res = h.helicsFederateEnterExecutingModeIterativeComplete(vFed1)
     assert res == h.HELICS_ITERATION_RESULT_NEXT_STEP
 
@@ -178,19 +177,22 @@ def test_bad_input_type_publication_2_tests():
     with pt.raises(h.HelicsException):
         h.helicsPublicationPublishNamedPoint(pubid, "hello world", 2.0)
 
-    destroyFederate(vFed1, fedinfo)
-    destroyBroker(broker)
+    destroy_federate(vFed1, fedinfo)
+    destroy_broker(broker)
 
 
 @pt.mark.skipif(sys.platform == "win32", reason="Fails to pass on windows")
 def test_bad_input_tests_raw_tests():
+    broker = create_broker(1)
+    vFed1, fedinfo = create_value_federate(1, "test")
 
-    broker = createBroker(1)
-    vFed1, fedinfo = createValueFederate(1, "test")
+    pubid = h.helicsFederateRegisterPublication(
+        vFed1, "pub1", h.HELICS_DATA_TYPE_RAW, ""
+    )
 
-    pubid = h.helicsFederateRegisterPublication(vFed1, "pub1", h.HELICS_DATA_TYPE_RAW, "")
-
-    subid = h.helicsFederateRegisterGlobalInput(vFed1, "inp1", h.HELICS_DATA_TYPE_RAW, "")
+    subid = h.helicsFederateRegisterGlobalInput(
+        vFed1, "inp1", h.HELICS_DATA_TYPE_RAW, ""
+    )
 
     h.helicsPublicationAddTarget(pubid, "inp1")
 
@@ -210,18 +212,19 @@ def test_bad_input_tests_raw_tests():
 
     h.helicsFederateDisconnect(vFed1)
 
-    t, res = h.helicsFederateRequestTimeIterative(vFed1, 1.0, h.HELICS_ITERATION_REQUEST_NO_ITERATION)
+    t, res = h.helicsFederateRequestTimeIterative(
+        vFed1, 1.0, h.HELICS_ITERATION_REQUEST_NO_ITERATION
+    )
     assert res == h.HELICS_ITERATION_RESULT_HALTED
 
-    destroyFederate(vFed1, fedinfo)
-    destroyBroker(broker)
+    destroy_federate(vFed1, fedinfo)
+    destroy_broker(broker)
 
 
 @pt.mark.skipif(sys.platform == "win32", reason="Fails to pass on windows")
 def test_bad_input_duplicate_publication_and_input_pathways():
-
-    broker = createBroker(1)
-    vFed1, fedinfo = createValueFederate(1, "fed0")
+    broker = create_broker(1)
+    vFed1, fedinfo = create_value_federate(1, "fed0")
 
     pubid = h.helicsFederateRegisterTypePublication(vFed1, "pub1", "string", "")
 
@@ -253,14 +256,14 @@ def test_bad_input_duplicate_publication_and_input_pathways():
 
     h.helicsFederateDisconnect(vFed1)
 
-    destroyFederate(vFed1, fedinfo)
-    destroyBroker(broker)
+    destroy_federate(vFed1, fedinfo)
+    destroy_broker(broker)
 
 
 @pt.mark.skipif(sys.platform == "win32", reason="Fails to pass on windows")
 def test_bad_input_init_error():
-    broker = createBroker(1)
-    vFed1, fedinfo = createValueFederate(1, "fed0")
+    broker = create_broker(1)
+    vFed1, fedinfo = create_value_federate(1, "fed0")
 
     # register the publications
 
@@ -310,24 +313,27 @@ def test_bad_input_init_error():
 
     h.helicsFederateDisconnect(vFed1)
 
-    destroyFederate(vFed1, fedinfo)
-    destroyBroker(broker)
+    destroy_federate(vFed1, fedinfo)
+    destroy_broker(broker)
 
 
 @pt.mark.skip(reason="Fails to pass on CI")
 def test_bad_inputs_input_tests():
-
-    broker = createBroker(1)
-    vFed1, fedinfo = createValueFederate(1, "fed0")
+    broker = create_broker(1)
+    vFed1, fedinfo = create_value_federate(1, "fed0")
 
     # register the publications
 
-    pubid = h.helicsFederateRegisterGlobalPublication(vFed1, "pub1", h.HELICS_DATA_TYPE_DOUBLE, "")
+    pubid = h.helicsFederateRegisterGlobalPublication(
+        vFed1, "pub1", h.HELICS_DATA_TYPE_DOUBLE, ""
+    )
 
     subid = h.helicsFederateRegisterInput(vFed1, "inp1", h.HELICS_DATA_TYPE_DOUBLE, "")
     # @test_throws h.HELICSErrorRegistrationFailure
     with pt.raises(h.HelicsException):
-        subid2 = h.helicsFederateRegisterInput(vFed1, "inp1", h.HELICS_DATA_TYPE_DOUBLE, "")
+        subid2 = h.helicsFederateRegisterInput(
+            vFed1, "inp1", h.HELICS_DATA_TYPE_DOUBLE, ""
+        )
 
     h.helicsInputAddTarget(subid, "pub1")
 
@@ -344,14 +350,18 @@ def test_bad_inputs_input_tests():
 
     h.helicsPublicationPublishDouble(pubid, 27.0)
 
-    comp = h.helicsFederateEnterExecutingModeIterative(vFed1, h.HELICS_ITERATION_REQUEST_FORCE_ITERATION)
+    comp = h.helicsFederateEnterExecutingModeIterative(
+        vFed1, h.HELICS_ITERATION_REQUEST_FORCE_ITERATION
+    )
     assert comp == h.HELICS_ITERATION_RESULT_ITERATING
     val = h.helicsInputGetDouble(subid)
     assert val == 27.0
     valt = h.helicsInputGetTime(subid)
     assert valt == 27.0
 
-    comp = h.helicsFederateEnterExecutingModeIterative(vFed1, h.HELICS_ITERATION_REQUEST_ITERATE_IF_NEEDED)
+    comp = h.helicsFederateEnterExecutingModeIterative(
+        vFed1, h.HELICS_ITERATION_REQUEST_ITERATE_IF_NEEDED
+    )
 
     assert comp == h.HELICS_ITERATION_RESULT_NEXT_STEP
 
@@ -374,14 +384,14 @@ def test_bad_inputs_input_tests():
 
     h.helicsFederateDisconnect(vFed1)
 
-    destroyFederate(vFed1, fedinfo)
-    destroyBroker(broker)
+    destroy_federate(vFed1, fedinfo)
+    destroy_broker(broker)
 
 
 @pt.mark.skipif(sys.platform == "win32", reason="Fails to pass on windows")
 def test_bad_inputs_core_link():
-    broker = createBroker(1)
-    vFed1, fedinfo = createValueFederate(1, "fed0")
+    broker = create_broker(1)
+    vFed1, fedinfo = create_value_federate(1, "fed0")
 
     # register the publications
 
@@ -416,15 +426,14 @@ def test_bad_inputs_core_link():
 
     h.helicsFederateDisconnect(vFed1)
 
-    destroyFederate(vFed1, fedinfo)
-    destroyBroker(broker)
+    destroy_federate(vFed1, fedinfo)
+    destroy_broker(broker)
 
 
 @pt.mark.skipif(sys.platform == "win32", reason="Fails to pass on windows")
 def test_bad_inputs_broker_link():
-
-    broker = createBroker(1)
-    vFed1, fedinfo = createValueFederate(1, "fed0")
+    broker = create_broker(1)
+    vFed1, fedinfo = create_value_federate(1, "fed0")
 
     # register the publications
 
@@ -452,17 +461,17 @@ def test_bad_inputs_broker_link():
 
     h.helicsFederateDisconnect(vFed1)
 
-    destroyFederate(vFed1, fedinfo)
+    destroy_federate(vFed1, fedinfo)
 
     h.helicsBrokerWaitForDisconnect(broker, 200)
 
-    destroyBroker(broker)
+    destroy_broker(broker)
 
 
 @pt.mark.skipif(sys.platform == "win32", reason="Fails to pass on windows")
 def test_bad_inputs_frees():
-    broker = createBroker(1)
-    vFed1, fedinfo = createValueFederate(1, "fed0")
+    broker = create_broker(1)
+    vFed1, fedinfo = create_value_federate(1, "fed0")
 
     fi = h.helicsCreateFederateInfo()
     h.helicsFederateInfoSetBroker(fi, "broker test")
@@ -477,15 +486,14 @@ def test_bad_inputs_frees():
 
     # @test_throws h.HELICSErrorInvalidObject
     with pt.raises(h.HelicsException):
-        destroyFederate(vFed1, fedinfo)
-    destroyBroker(broker)
+        destroy_federate(vFed1, fedinfo)
+    destroy_broker(broker)
 
 
 @pt.mark.skipif(sys.platform == "win32", reason="Fails to pass on windows")
 def test_bad_inputs_init_error_5():
-
-    broker = createBroker(1)
-    vFed1, fedinfo = createValueFederate(1, "fed0")
+    broker = create_broker(1)
+    vFed1, fedinfo = create_value_federate(1, "fed0")
     # register the publications
 
     h.helicsFederateInfoSetSeparator(fedinfo, "-")
@@ -501,11 +509,15 @@ def test_bad_inputs_init_error_5():
 
     # @test_throws h.HELICSErrorConnectionFailure
     with pt.raises(h.HelicsException):
-        resIt = h.helicsFederateEnterExecutingModeIterative(vFed1, h.HELICS_ITERATION_REQUEST_NO_ITERATION)
+        resIt = h.helicsFederateEnterExecutingModeIterative(
+            vFed1, h.HELICS_ITERATION_REQUEST_NO_ITERATION
+        )
 
     # @test_throws h.HELICSErrorInvalidFunctionCall
     with pt.raises(h.HelicsException):
-        h.helicsFederateRequestTimeIterativeAsync(vFed1, 1.0, h.HELICS_ITERATION_REQUEST_NO_ITERATION)
+        h.helicsFederateRequestTimeIterativeAsync(
+            vFed1, 1.0, h.HELICS_ITERATION_REQUEST_NO_ITERATION
+        )
 
     # @test_throws h.HELICSErrorInvalidFunctionCall
     with pt.raises(h.HelicsException):
@@ -513,20 +525,25 @@ def test_bad_inputs_init_error_5():
 
     h.helicsFederateDisconnect(vFed1)
 
-    destroyFederate(vFed1, fedinfo)
+    destroy_federate(vFed1, fedinfo)
 
-    destroyBroker(broker)
+    destroy_broker(broker)
 
 
 @pt.mark.skipif(sys.platform == "win32", reason="Fails to pass on windows")
 def test_bad_inputs_misc_tests():
-
     with pt.raises(h.HelicsException):
         assert h.helicsGetPropertyIndex("") == h.HELICS_PROPERTY_INVALID_OPTION_INDEX
     with pt.raises(h.HelicsException):
-        assert h.helicsGetPropertyIndex("not_a_property") == h.HELICS_PROPERTY_INVALID_OPTION_INDEX
+        assert (
+            h.helicsGetPropertyIndex("not_a_property")
+            == h.HELICS_PROPERTY_INVALID_OPTION_INDEX
+        )
 
     with pt.raises(h.HelicsException):
         assert h.helicsGetOptionIndex("") == h.HELICS_PROPERTY_INVALID_OPTION_INDEX
     with pt.raises(h.HelicsException):
-        assert h.helicsGetOptionIndex("not_a_property") == h.HELICS_PROPERTY_INVALID_OPTION_INDEX
+        assert (
+            h.helicsGetOptionIndex("not_a_property")
+            == h.HELICS_PROPERTY_INVALID_OPTION_INDEX
+        )

--- a/tests/test_combinationfederate.py
+++ b/tests/test_combinationfederate.py
@@ -2,26 +2,23 @@
 import os
 import sys
 
-CURRENT_DIRECTORY = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
-
-sys.path.append(CURRENT_DIRECTORY)
-sys.path.append(os.path.dirname(CURRENT_DIRECTORY))
-
 import helics as h
-import os
 import pytest as pt
 
-from test_init import createBroker, createValueFederate, destroyFederate, destroyBroker
+from .utils import (
+    create_broker,
+)
 
 CURRENT_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
 
 
-@pt.mark.skipif(sys.platform == "linux", reason = "Fails on CI on Linux")
+@pt.mark.skipif(sys.platform == "linux", reason="Fails on CI on Linux")
 def test_combination_federate():
+    broker = create_broker()
 
-    broker = createBroker()
-
-    cfed = h.helicsCreateCombinationFederateFromConfig(os.path.join(CURRENT_DIRECTORY, "combinationfederate.json"))
+    cfed = h.helicsCreateCombinationFederateFromConfig(
+        os.path.join(CURRENT_DIRECTORY, "combinationfederate.json")
+    )
 
     assert h.helicsFederateIsValid(cfed)
 
@@ -42,4 +39,3 @@ def test_combination_federate():
     h.helicsFederateDestroy(cfed)
     h.helicsFederateFree(cfed)
     h.helicsBrokerDestroy(broker)
-    h.helicsCloseLibrary()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,28 +1,26 @@
 # -*- coding: utf-8 -*-
 import os
-import sys
-
-CURRENT_DIRECTORY = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
-
-sys.path.append(CURRENT_DIRECTORY)
-sys.path.append(os.path.dirname(CURRENT_DIRECTORY))
 
 import helics as h
 import os
 
-import pytest
 import pytest as pt
 
-from test_init import createBroker, createValueFederate, destroyFederate, destroyBroker, createMessageFederate
+from .utils import (
+    assert_attributes,
+    create_broker,
+    destroy_federate,
+    destroy_broker,
+    create_message_federate,
+)
 
 CURRENT_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
 
 
 def test_filter_type_tests_registration():
-
-    broker = createBroker(2)
-    fFed, fedinfo1 = createMessageFederate(1, "filter")
-    mFed, fedinfo2 = createMessageFederate(1, "message")
+    broker = create_broker(2)
+    fFed, fedinfo1 = create_message_federate(1, "filter")
+    mFed, fedinfo2 = create_message_federate(1, "message")
 
     h.helicsFederateRegisterGlobalEndpoint(mFed, "port1", "")
     h.helicsFederateRegisterGlobalEndpoint(mFed, "port2", "")
@@ -60,16 +58,15 @@ def test_filter_type_tests_registration():
     state = h.helicsFederateGetState(fFed)
     assert state == h.HELICS_STATE_FINALIZE
 
-    destroyFederate(fFed, fedinfo1)
-    destroyFederate(mFed, fedinfo2)
-    destroyBroker(broker)
+    destroy_federate(fFed, fedinfo1)
+    destroy_federate(mFed, fedinfo2)
+    destroy_broker(broker)
 
 
 def test_filter_type_tests_info():
-
-    broker = createBroker(2)
-    fFed, fedinfo1 = createMessageFederate(1, "filter")
-    mFed, fedinfo2 = createMessageFederate(1, "message")
+    broker = create_broker(2)
+    fFed, fedinfo1 = create_message_federate(1, "filter")
+    mFed, fedinfo2 = create_message_federate(1, "message")
 
     p1 = h.helicsFederateRegisterGlobalEndpoint(mFed, "port1", "")
     p2 = h.helicsFederateRegisterGlobalEndpoint(mFed, "port2", "")
@@ -107,13 +104,12 @@ def test_filter_type_tests_info():
     h.helicsFederateDisconnect(fFed)
     h.helicsFederateDisconnectComplete(mFed)
 
-    destroyFederate(fFed, fedinfo1)
-    destroyFederate(mFed, fedinfo2)
-    destroyBroker(broker)
+    destroy_federate(fFed, fedinfo1)
+    destroy_federate(mFed, fedinfo2)
+    destroy_broker(broker)
 
 
 def test_filter_types_tests_core_filter_registration():
-
     core1 = h.helicsCreateCore("inproc", "core1", "--autobroker")
 
     core2 = h.helicsCoreClone(core1)
@@ -122,10 +118,14 @@ def test_filter_types_tests_core_filter_registration():
 
     assert core1IdentifierString == "core1"
 
-    sourceFilter1 = h.helicsCoreRegisterFilter(core1, h.HELICS_FILTER_TYPE_DELAY, "core1SourceFilter")
+    sourceFilter1 = h.helicsCoreRegisterFilter(
+        core1, h.HELICS_FILTER_TYPE_DELAY, "core1SourceFilter"
+    )
 
     h.helicsFilterAddSourceTarget(sourceFilter1, "ep1")
-    destinationFilter1 = h.helicsCoreRegisterFilter(core1, h.HELICS_FILTER_TYPE_DELAY, "core1DestinationFilter")
+    destinationFilter1 = h.helicsCoreRegisterFilter(
+        core1, h.HELICS_FILTER_TYPE_DELAY, "core1DestinationFilter"
+    )
 
     h.helicsFilterAddDestinationTarget(destinationFilter1, "ep2")
     cloningFilter1 = h.helicsCoreRegisterCloningFilter(core1, "ep3")
@@ -142,12 +142,13 @@ def test_filter_types_tests_core_filter_registration():
 
 
 def test_filter_type_tests_message_filter_function():
+    broker = create_broker(2)
+    fFed, fedinfo1 = create_message_federate(1, "filter")
+    mFed, fedinfo2 = create_message_federate(1, "message")
 
-    broker = createBroker(2)
-    fFed, fedinfo1 = createMessageFederate(1, "filter")
-    mFed, fedinfo2 = createMessageFederate(1, "message")
-
-    h.helicsFederateSetFlagOption(mFed, h.HELICS_FLAG_IGNORE_TIME_MISMATCH_WARNINGS, True)
+    h.helicsFederateSetFlagOption(
+        mFed, h.HELICS_FLAG_IGNORE_TIME_MISMATCH_WARNINGS, True
+    )
     p1 = h.helicsFederateRegisterGlobalEndpoint(mFed, "port1", "")
     p2 = h.helicsFederateRegisterGlobalEndpoint(mFed, "port2", "")
 
@@ -195,25 +196,28 @@ def test_filter_type_tests_message_filter_function():
     state = h.helicsFederateGetState(fFed)
     assert state == h.HELICS_STATE_FINALIZE
 
-    destroyFederate(fFed, fedinfo1)
-    destroyFederate(mFed, fedinfo2)
-    destroyBroker(broker)
+    destroy_federate(fFed, fedinfo1)
+    destroy_federate(mFed, fedinfo2)
+    destroy_broker(broker)
 
 
 def test_filter_test_types_function_mobj():
+    broker = create_broker(2)
+    fFed, fedinfo1 = create_message_federate(1, "filter")
+    mFed, fedinfo2 = create_message_federate(1, "message")
 
-    broker = createBroker(2)
-    fFed, fedinfo1 = createMessageFederate(1, "filter")
-    mFed, fedinfo2 = createMessageFederate(1, "message")
-
-    h.helicsFederateSetFlagOption(mFed, h.HELICS_FLAG_IGNORE_TIME_MISMATCH_WARNINGS, True)
+    h.helicsFederateSetFlagOption(
+        mFed, h.HELICS_FLAG_IGNORE_TIME_MISMATCH_WARNINGS, True
+    )
     p1 = h.helicsFederateRegisterGlobalEndpoint(mFed, "port1", "")
     p2 = h.helicsFederateRegisterGlobalEndpoint(mFed, "port2", "")
 
     f1 = h.helicsFederateRegisterFilter(fFed, h.HELICS_FILTER_TYPE_DELAY, "filter1")
     h.helicsFilterAddSourceTarget(f1, "port1")
     h.helicsFilterSet(
-        f1, "delay", 2.5,
+        f1,
+        "delay",
+        2.5,
     )
 
     h.helicsFederateEnterExecutingModeAsync(fFed)
@@ -258,17 +262,16 @@ def test_filter_test_types_function_mobj():
     state = h.helicsFederateGetState(fFed)
     assert state == h.HELICS_STATE_FINALIZE
 
-    destroyFederate(fFed, fedinfo1)
-    destroyFederate(mFed, fedinfo2)
-    destroyBroker(broker)
+    destroy_federate(fFed, fedinfo1)
+    destroy_federate(mFed, fedinfo2)
+    destroy_broker(broker)
 
 
 def test_filter_test_types_function_two_stage():
-
-    broker = createBroker(3)
-    fFed, fedinfo1 = createMessageFederate(1, "filter")
-    fFed2, fedinfo2 = createMessageFederate(1, "filter2")
-    mFed, fedinfo3 = createMessageFederate(1, "message")
+    broker = create_broker(3)
+    fFed, fedinfo1 = create_message_federate(1, "filter")
+    fFed2, fedinfo2 = create_message_federate(1, "filter2")
+    mFed, fedinfo3 = create_message_federate(1, "message")
 
     p1 = h.helicsFederateRegisterGlobalEndpoint(mFed, "port1", "")
     p2 = h.helicsFederateRegisterGlobalEndpoint(mFed, "port2", "")
@@ -328,17 +331,16 @@ def test_filter_test_types_function_two_stage():
     state = h.helicsFederateGetState(fFed)
     assert state == h.HELICS_STATE_FINALIZE
 
-    destroyFederate(fFed, fedinfo1)
-    destroyFederate(fFed2, fedinfo2)
-    destroyFederate(mFed, fedinfo3)
-    destroyBroker(broker)
+    destroy_federate(fFed, fedinfo1)
+    destroy_federate(fFed2, fedinfo2)
+    destroy_federate(mFed, fedinfo3)
+    destroy_broker(broker)
 
 
 def test_filter_test_types_function2():
-
-    broker = createBroker(2)
-    fFed, fedinfo1 = createMessageFederate(1, "filter")
-    mFed, fedinfo2 = createMessageFederate(1, "message")
+    broker = create_broker(2)
+    fFed, fedinfo1 = create_message_federate(1, "filter")
+    mFed, fedinfo2 = create_message_federate(1, "message")
 
     p1 = h.helicsFederateRegisterGlobalEndpoint(mFed, "port1", "")
     p2 = h.helicsFederateRegisterGlobalEndpoint(mFed, "port2", "")
@@ -399,27 +401,32 @@ def test_filter_test_types_function2():
     state = h.helicsFederateGetState(fFed)
     assert state == h.HELICS_STATE_FINALIZE
 
-    destroyFederate(fFed, fedinfo1)
-    destroyFederate(mFed, fedinfo2)
-    destroyBroker(broker)
+    destroy_federate(fFed, fedinfo1)
+    destroy_federate(mFed, fedinfo2)
+    destroy_broker(broker)
 
 
 def test_filter_test_types_message_filter_function3():
-
-    broker = createBroker(2)
-    fFed, fedinfo1 = createMessageFederate(1, "filter", 1)
-    mFed, fedinfo2 = createMessageFederate(1, "message", 1)
+    broker = create_broker(2)
+    fFed, fedinfo1 = create_message_federate(1, "filter", 1)
+    mFed, fedinfo2 = create_message_federate(1, "message", 1)
 
     p1 = h.helicsFederateRegisterGlobalEndpoint(mFed, "port1", "")
     p2 = h.helicsFederateRegisterGlobalEndpoint(mFed, "port2", "random")
 
-    f1 = h.helicsFederateRegisterGlobalFilter(fFed, h.HELICS_FILTER_TYPE_CUSTOM, "filter1")
+    f1 = h.helicsFederateRegisterGlobalFilter(
+        fFed, h.HELICS_FILTER_TYPE_CUSTOM, "filter1"
+    )
     h.helicsFilterAddSourceTarget(f1, "port1")
-    f2 = h.helicsFederateRegisterGlobalFilter(fFed, h.HELICS_FILTER_TYPE_DELAY, "filter2")
+    f2 = h.helicsFederateRegisterGlobalFilter(
+        fFed, h.HELICS_FILTER_TYPE_DELAY, "filter2"
+    )
     h.helicsFilterAddSourceTarget(f2, "port1")
 
     h.helicsFederateRegisterEndpoint(fFed, "fout", "")
-    f3 = h.helicsFederateRegisterFilter(fFed, h.HELICS_FILTER_TYPE_RANDOM_DELAY, "filter3")
+    f3 = h.helicsFederateRegisterFilter(
+        fFed, h.HELICS_FILTER_TYPE_RANDOM_DELAY, "filter3"
+    )
     h.helicsFilterAddSourceTarget(f3, "filter0/fout")
 
     h.helicsFilterSet(f2, "delay", 2.5)
@@ -467,17 +474,16 @@ def test_filter_test_types_message_filter_function3():
     state = h.helicsFederateGetState(fFed)
     assert state == h.HELICS_STATE_FINALIZE
 
-    destroyFederate(mFed, fedinfo1)
-    destroyFederate(fFed, fedinfo2)
-    destroyBroker(broker)
+    destroy_federate(mFed, fedinfo1)
+    destroy_federate(fFed, fedinfo2)
+    destroy_broker(broker)
 
 
 def test_filter_test_types_clone_test():
-
-    broker = createBroker(3)
-    sFed, fedinfo1 = createMessageFederate(1, "source", 1)
-    dFed, fedinfo2 = createMessageFederate(1, "dest", 1)
-    dcFed, fedinfo3 = createMessageFederate(1, "dest_clone", 1)
+    broker = create_broker(3)
+    sFed, fedinfo1 = create_message_federate(1, "source", 1)
+    dFed, fedinfo2 = create_message_federate(1, "dest", 1)
+    dcFed, fedinfo3 = create_message_federate(1, "dest_clone", 1)
 
     p1 = h.helicsFederateRegisterGlobalEndpoint(sFed, "src", "")
     p2 = h.helicsFederateRegisterGlobalEndpoint(dFed, "dest", "")
@@ -534,18 +540,21 @@ def test_filter_test_types_clone_test():
     state = h.helicsFederateGetState(sFed)
     assert state == h.HELICS_STATE_FINALIZE
 
-    destroyFederate(sFed, fedinfo1)
-    destroyFederate(dFed, fedinfo2)
-    destroyFederate(dcFed, fedinfo3)
-    destroyBroker(broker)
+    destroy_federate(sFed, fedinfo1)
+    destroy_federate(dFed, fedinfo2)
+    destroy_federate(dcFed, fedinfo3)
+    destroy_broker(broker)
 
 
 def test_filter_test_types_clone_test_connections():
-
-    broker = createBroker(3)
-    sFed, fedinfo1 = createMessageFederate(1, "source", 1.0,)
-    dFed, fedinfo2 = createMessageFederate(1, "dest", 1.0)
-    dcFed, fedinfo3 = createMessageFederate(1, "dest_clone", 1.0)
+    broker = create_broker(3)
+    sFed, fedinfo1 = create_message_federate(
+        1,
+        "source",
+        1.0,
+    )
+    dFed, fedinfo2 = create_message_federate(1, "dest", 1.0)
+    dcFed, fedinfo3 = create_message_federate(1, "dest_clone", 1.0)
 
     p1 = h.helicsFederateRegisterGlobalEndpoint(sFed, "src", "")
     p2 = h.helicsFederateRegisterGlobalEndpoint(dFed, "dest", "")
@@ -606,17 +615,17 @@ def test_filter_test_types_clone_test_connections():
     state = h.helicsFederateGetState(sFed)
     assert state == h.HELICS_STATE_FINALIZE
 
-    destroyFederate(sFed, fedinfo1)
-    destroyFederate(dFed, fedinfo2)
-    destroyFederate(dcFed, fedinfo3)
-    destroyBroker(broker)
+    destroy_federate(sFed, fedinfo1)
+    destroy_federate(dFed, fedinfo2)
+    destroy_federate(dcFed, fedinfo3)
+    destroy_broker(broker)
 
 
 def test_filter_test_types_clone_test_broker_connections():
-    broker = createBroker(3)
-    sFed, fedinfo1 = createMessageFederate(1, "source", 1.0)
-    dFed, fedinfo2 = createMessageFederate(1, "dest", 1.0)
-    dcFed, fedinfo3 = createMessageFederate(1, "dest_clone", 1.0)
+    broker = create_broker(3)
+    sFed, fedinfo1 = create_message_federate(1, "source", 1.0)
+    dFed, fedinfo2 = create_message_federate(1, "dest", 1.0)
+    dcFed, fedinfo3 = create_message_federate(1, "dest_clone", 1.0)
 
     p1 = h.helicsFederateRegisterGlobalEndpoint(sFed, "src", "")
     p2 = h.helicsFederateRegisterGlobalEndpoint(dFed, "dest", "")
@@ -670,18 +679,18 @@ def test_filter_test_types_clone_test_broker_connections():
     state = h.helicsFederateGetState(sFed)
     assert state == h.HELICS_STATE_FINALIZE
 
-    destroyFederate(sFed, fedinfo1)
-    destroyFederate(dFed, fedinfo2)
-    destroyFederate(dcFed, fedinfo3)
-    destroyBroker(broker)
+    destroy_federate(sFed, fedinfo1)
+    destroy_federate(dFed, fedinfo2)
+    destroy_federate(dcFed, fedinfo3)
+    destroy_broker(broker)
 
 
 @pt.mark.skip(reason="Fails to run on Windows")
 def test_filter_test_types_clone_test_dest_connections():
-    broker = createBroker(3)
-    sFed, fedinfo1 = createMessageFederate(1, "source", 1.0)
-    dFed, fedinfo2 = createMessageFederate(1, "dest", 1.0)
-    dcFed, fedinfo3 = createMessageFederate(1, "dest_clone", 2.0)
+    broker = create_broker(3)
+    sFed, fedinfo1 = create_message_federate(1, "source", 1.0)
+    dFed, fedinfo2 = create_message_federate(1, "dest", 1.0)
+    dcFed, fedinfo3 = create_message_federate(1, "dest_clone", 2.0)
 
     p1 = h.helicsFederateRegisterGlobalEndpoint(sFed, "src", "")
     _ = h.helicsFederateRegisterGlobalEndpoint(dFed, "dest", "")
@@ -756,10 +765,10 @@ def test_filter_test_types_clone_test_dest_connections():
     # (state = h.helicsFederateGetState(sFed))
     # (state == h.helics_state_finalize)
 
-    destroyFederate(sFed, fedinfo1)
-    destroyFederate(dFed, fedinfo2)
-    destroyFederate(dcFed, fedinfo3)
-    destroyBroker(broker)
+    destroy_federate(sFed, fedinfo1)
+    destroy_federate(dFed, fedinfo2)
+    destroy_federate(dcFed, fedinfo3)
+    destroy_broker(broker)
 
 
 try:
@@ -787,26 +796,45 @@ class UserData(object):
 
 @pt.mark.skip(reason="Fails to pass on CI")
 def test_filter_callback_test():
+    broker = create_broker(2)
+    assert isinstance(broker, h.HelicsBroker)
+    assert_attributes(
+        broker, {"identifier": "mainbroker", "address": "tcp://127.0.0.1:23404"}
+    )
 
-    broker = createBroker(2)
+    fFed, fedinfo1 = create_message_federate(1, "filter", 1.0)
+    mFed, fedinfo2 = create_message_federate(1, "message", 1.0)
 
-    assert """helics.HelicsBroker(identifier = "mainbroker", address = "tcp://127.0.0.1:23404")""" in repr(broker)
-
-    fFed, fedinfo1 = createMessageFederate(1, "filter", 1.0)
-    mFed, fedinfo2 = createMessageFederate(1, "message", 1.0)
-
-    h.helicsFederateSetFlagOption(mFed, h.HELICS_FLAG_IGNORE_TIME_MISMATCH_WARNINGS, True)
+    h.helicsFederateSetFlagOption(
+        mFed, h.HELICS_FLAG_IGNORE_TIME_MISMATCH_WARNINGS, True
+    )
 
     p1 = h.helicsFederateRegisterGlobalEndpoint(mFed, "port1")
     p2 = h.helicsFederateRegisterGlobalEndpoint(mFed, "port2", "")
 
-    assert (
-        """helics.HelicsEndpoint(name = "port1", type = "", info = "", is_valid = True, default_destination = "", n_pending_messages = 0)"""
-        in repr(p1)
+    assert isinstance(p1, h.HelicsEndpoint)
+    assert isinstance(p2, h.HelicsEndpoint)
+    assert_attributes(
+        p1,
+        {
+            "name": "port1",
+            "type": "",
+            "info": "",
+            "is_valid": True,
+            "default_destination": "",
+            "n_pending_messages": 0,
+        },
     )
-    assert (
-        """helics.HelicsEndpoint(name = "port2", type = "", info = "", is_valid = True, default_destination = "", n_pending_messages = 0)"""
-        in repr(p2)
+    assert_attributes(
+        p2,
+        {
+            "name": "port2",
+            "type": "",
+            "info": "",
+            "is_valid": True,
+            "default_destination": "",
+            "n_pending_messages": 0,
+        },
     )
 
     f1 = h.helicsFederateRegisterFilter(fFed, h.HELICS_FILTER_TYPE_CUSTOM, "filter1")
@@ -814,7 +842,7 @@ def test_filter_callback_test():
 
     h.helicsFilterAddSourceTarget(f1, "port1")
 
-    assert 'name = "Testfilter/filter1"' in repr(f1)
+    assert f1.name == "Testfilter/filter1"
 
     userdata = UserData(5)
 
@@ -824,27 +852,43 @@ def test_filter_callback_test():
     with pt.raises(h.HelicsException):
         h.helicsFilterSetCustomCallback(f2, filterFunc1, handle)
 
-    assert (
-        """helics.HelicsMessageFederate(name = "Testfilter", state = HelicsFederateState.STARTUP, current_time = -9223372036.854776, n_publications = 0, n_subscriptions = 0, n_endpoints = 0, n_filters = 1, n_pending_messages = 0)"""
-        in repr(fFed)
+    default_federate_attributes = {
+        "name": "",
+        "state": h.HelicsFederateState.STARTUP,
+        "current_time": -9223372036.854776,
+        "n_publications": 0,
+        "n_subscriptions": 0,
+        "n_endpoints": 0,
+        "n_filters": 0,
+        "n_pending_messages": 0,
+    }
+    assert isinstance(fFed, h.HelicsMessageFederate)
+    assert isinstance(mFed, h.HelicsMessageFederate)
+
+    assert_attributes(
+        fFed,
+        {**default_federate_attributes, "name": "Testfilter", "n_filters": 1},
     )
-    assert (
-        """helics.HelicsMessageFederate(name = "Testmessage", state = HelicsFederateState.STARTUP, current_time = -9223372036.854776, n_publications = 0, n_subscriptions = 0, n_endpoints = 2, n_filters = 1, n_pending_messages = 0)"""
-        in repr(mFed)
+
+    assert_attributes(
+        mFed,
+        {
+            **default_federate_attributes,
+            "name": "Testmessage",
+            "n_endpoints": 2,
+            "n_filters": 1,
+        },
     )
 
     h.helicsFederateEnterExecutingModeAsync(fFed)
     h.helicsFederateEnterExecutingMode(mFed)
     h.helicsFederateEnterExecutingModeComplete(fFed)
 
-    assert (
-        """helics.HelicsMessageFederate(name = "Testfilter", state = HelicsFederateState.EXECUTION, current_time = 0.0, n_publications = 0, n_subscriptions = 0, n_endpoints = 0, n_filters = 1, n_pending_messages = 0)"""
-        in repr(fFed)
-    )
-    assert (
-        """helics.HelicsMessageFederate(name = "Testmessage", state = HelicsFederateState.EXECUTION, current_time = 0.0, n_publications = 0, n_subscriptions = 0, n_endpoints = 2, n_filters = 1, n_pending_messages = 0)"""
-        in repr(mFed)
-    )
+    assert fFed.state == h.HelicsFederateState.EXECUTION
+    assert mFed.state == h.HelicsFederateState.EXECUTION
+
+    assert fFed.current_time == 0.0
+    assert mFed.current_time == 0.0
 
     state = h.helicsFederateGetState(fFed)
     assert state == h.HELICS_STATE_EXECUTION
@@ -882,18 +926,17 @@ def test_filter_callback_test():
     state = h.helicsFederateGetState(fFed)
     assert state == h.HELICS_STATE_FINALIZE
 
-    destroyFederate(fFed, fedinfo1)
-    destroyFederate(mFed, fedinfo2)
-    destroyBroker(broker)
+    destroy_federate(fFed, fedinfo1)
+    destroy_federate(mFed, fedinfo2)
+    destroy_broker(broker)
 
 
 @pt.mark.skip(reason="Fails to pass on CI")
 def test_filter_test_types_clone_test_broker_dest_connections():
-
-    broker = createBroker(3)
-    sFed, fedinfo1 = createMessageFederate(1, "source", 1.0)
-    dFed, fedinfo2 = createMessageFederate(1, "dest", 1.0)
-    dcFed, fedinfo3 = createMessageFederate(1, "dest_clone", 1.0)
+    broker = create_broker(3)
+    sFed, fedinfo1 = create_message_federate(1, "source", 1.0)
+    dFed, fedinfo2 = create_message_federate(1, "dest", 1.0)
+    dcFed, fedinfo3 = create_message_federate(1, "dest_clone", 1.0)
 
     p1 = h.helicsFederateRegisterGlobalEndpoint(sFed, "src", "")
     p2 = h.helicsFederateRegisterGlobalEndpoint(dFed, "dest", "")
@@ -957,14 +1000,13 @@ def test_filter_test_types_clone_test_broker_dest_connections():
     state = h.helicsFederateGetState(sFed)
     assert state == h.HELICS_STATE_FINALIZE
 
-    destroyFederate(sFed, fedinfo1)
-    destroyFederate(dFed, fedinfo2)
-    destroyFederate(dcFed, fedinfo3)
-    destroyBroker(broker)
+    destroy_federate(sFed, fedinfo1)
+    destroy_federate(dFed, fedinfo2)
+    destroy_federate(dcFed, fedinfo3)
+    destroy_broker(broker)
 
 
 def test_filter_test_file_load():
-
     filename = os.path.join(CURRENT_DIRECTORY, "filters.json")
     mFed = h.helicsCreateMessageFederateFromConfig(filename)
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -138,7 +138,6 @@ def test_filter_types_tests_core_filter_registration():
     h.helicsCoreDisconnect(core2)
     # h.helicsCoreFree(core1)
     # h.helicsCoreFree(core2)
-    h.helicsCloseLibrary()
 
 
 def test_filter_type_tests_message_filter_function():
@@ -1015,4 +1014,3 @@ def test_filter_test_file_load():
 
     assert h.helicsFederateGetEndpointCount(mFed) == 3
     h.helicsFederateDisconnect(mFed)
-    h.helicsCloseLibrary()

--- a/tests/test_iteration.py
+++ b/tests/test_iteration.py
@@ -1,26 +1,26 @@
 # -*- coding: utf-8 -*-
-import os
 import sys
 
-CURRENT_DIRECTORY = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
-
-sys.path.append(CURRENT_DIRECTORY)
-sys.path.append(os.path.dirname(CURRENT_DIRECTORY))
-
-import time
 import helics as h
 import pytest as pt
 
-from test_init import createBroker, createValueFederate, destroyFederate, destroyBroker
+from .utils import (
+    create_broker,
+    create_value_federate,
+    destroy_federate,
+    destroy_broker,
+)
+
 
 @pt.mark.skipif(sys.platform == "win32", reason="Fails to pass on windows")
 def test_iteration_execution_iteration_test():
-
-    broker = createBroker(1)
-    vFed1, fedinfo = createValueFederate(1, "fed0")
+    broker = create_broker(1)
+    vFed1, fedinfo = create_value_federate(1, "fed0")
     # register the publications
 
-    pubid = h.helicsFederateRegisterGlobalPublication(vFed1, "pub1", h.HELICS_DATA_TYPE_DOUBLE, "")
+    pubid = h.helicsFederateRegisterGlobalPublication(
+        vFed1, "pub1", h.HELICS_DATA_TYPE_DOUBLE, ""
+    )
 
     subid = h.helicsFederateRegisterSubscription(vFed1, "pub1", "")
     h.helicsFederateSetTimeProperty(vFed1, h.HELICS_PROPERTY_TIME_DELTA, 1.0)
@@ -28,12 +28,16 @@ def test_iteration_execution_iteration_test():
     h.helicsFederateEnterInitializingMode(vFed1)
     h.helicsPublicationPublishDouble(pubid, 27.0)
 
-    comp = h.helicsFederateEnterExecutingModeIterative(vFed1, h.HELICS_ITERATION_REQUEST_ITERATE_IF_NEEDED)
+    comp = h.helicsFederateEnterExecutingModeIterative(
+        vFed1, h.HELICS_ITERATION_REQUEST_ITERATE_IF_NEEDED
+    )
     assert comp == h.HELICS_ITERATION_RESULT_ITERATING
     val = h.helicsInputGetDouble(subid)
     assert val == 27.0
 
-    comp = h.helicsFederateEnterExecutingModeIterative(vFed1, h.HELICS_ITERATION_REQUEST_ITERATE_IF_NEEDED)
+    comp = h.helicsFederateEnterExecutingModeIterative(
+        vFed1, h.HELICS_ITERATION_REQUEST_ITERATE_IF_NEEDED
+    )
 
     assert comp == h.HELICS_ITERATION_RESULT_NEXT_STEP
 
@@ -42,22 +46,25 @@ def test_iteration_execution_iteration_test():
     assert val2 == val
 
     h.helicsFederateDisconnect(vFed1)
-    destroyFederate(vFed1, fedinfo)
-    destroyBroker(broker)
+    destroy_federate(vFed1, fedinfo)
+    destroy_broker(broker)
 
 
 @pt.mark.skipif(sys.platform == "win32", reason="Fails to pass on windows")
 def test_iteration_async_test():
-
-    broker = createBroker(1)
-    vFed1, fedinfo1 = createValueFederate(1, "fed0")
-    vFed2, fedinfo2 = createValueFederate(1, "fed1")
+    broker = create_broker(1)
+    vFed1, fedinfo1 = create_value_federate(1, "fed0")
+    vFed2, fedinfo2 = create_value_federate(1, "fed1")
 
     # register the publications
-    pub1 = h.helicsFederateRegisterGlobalPublication(vFed1, "pub1", h.HELICS_DATA_TYPE_INT)
+    pub1 = h.helicsFederateRegisterGlobalPublication(
+        vFed1, "pub1", h.HELICS_DATA_TYPE_INT
+    )
 
     sub1 = h.helicsFederateRegisterSubscription(vFed2, "pub1")
-    pub2 = h.helicsFederateRegisterGlobalPublication(vFed2, "pub2", h.HELICS_DATA_TYPE_INT)
+    pub2 = h.helicsFederateRegisterGlobalPublication(
+        vFed2, "pub2", h.HELICS_DATA_TYPE_INT
+    )
 
     sub2 = h.helicsFederateRegisterSubscription(vFed1, "pub2")
     h.helicsFederateSetTimeProperty(vFed1, h.HELICS_PROPERTY_TIME_PERIOD, 1.0)
@@ -89,9 +96,13 @@ def test_iteration_async_test():
             h.helicsPublicationPublishInteger(pub1, c1)
             h.helicsPublicationPublishInteger(pub2, c2)
 
-        h.helicsFederateRequestTimeIterativeAsync(vFed1, 1.0, h.HELICS_ITERATION_REQUEST_ITERATE_IF_NEEDED)
+        h.helicsFederateRequestTimeIterativeAsync(
+            vFed1, 1.0, h.HELICS_ITERATION_REQUEST_ITERATE_IF_NEEDED
+        )
 
-        grantedTime, state = h.helicsFederateRequestTimeIterative(vFed2, 1.0, h.HELICS_ITERATION_REQUEST_ITERATE_IF_NEEDED)
+        grantedTime, state = h.helicsFederateRequestTimeIterative(
+            vFed2, 1.0, h.HELICS_ITERATION_REQUEST_ITERATE_IF_NEEDED
+        )
         if c1 <= 10:
             # assert state == h.HELICS_ITERATION_RESULT_ITERATING
             assert grantedTime == 0.0
@@ -106,6 +117,6 @@ def test_iteration_async_test():
             # assert state == h.HELICS_ITERATION_RESULT_NEXT_STEP
             # assert grantedTime == 1.0
 
-    destroyFederate(vFed1, fedinfo1)
-    destroyFederate(vFed2, fedinfo2)
-    destroyBroker(broker)
+    destroy_federate(vFed1, fedinfo1)
+    destroy_federate(vFed2, fedinfo2)
+    destroy_broker(broker)

--- a/tests/test_messagefederate.py
+++ b/tests/test_messagefederate.py
@@ -61,7 +61,6 @@ def mFed():
 
     h.helicsFederateInfoFree(fedinfo)
     h.helicsFederateFree(mFed)
-    h.helicsCloseLibrary()
 
 
 def test_message_federate_initialize(mFed):

--- a/tests/test_messagefederate.py
+++ b/tests/test_messagefederate.py
@@ -1,17 +1,14 @@
 # -*- coding: utf-8 -*-
-import os
-import sys
-
-CURRENT_DIRECTORY = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
-
-sys.path.append(CURRENT_DIRECTORY)
-sys.path.append(os.path.dirname(CURRENT_DIRECTORY))
-
 import time
 import helics as h
 import pytest as pt
 
-from test_init import createBroker, createValueFederate, destroyFederate, destroyBroker, createMessageFederate
+from .utils import (
+    create_broker,
+    destroy_federate,
+    destroy_broker,
+    create_message_federate,
+)
 
 
 @pt.fixture
@@ -131,7 +128,6 @@ def test_message_federate_send(mFed):
 
 
 def test_messagefederate_test_message_federate_initialize(mFed):
-
     state = h.helicsFederateGetState(mFed)
     assert state == 0
     h.helicsFederateEnterExecutingMode(mFed)
@@ -141,7 +137,6 @@ def test_messagefederate_test_message_federate_initialize(mFed):
 
 
 def test_messagefederate_test_message_federate_endpoint_registration(mFed):
-
     epid1 = h.helicsFederateRegisterEndpoint(mFed, "ep1", "")
     epid2 = h.helicsFederateRegisterGlobalEndpoint(mFed, "ep2", "random")
 
@@ -171,7 +166,6 @@ def test_messagefederate_test_message_federate_endpoint_registration(mFed):
 
 
 def test_messagefederate_test_message_federate_send(mFed):
-
     epid1 = h.helicsFederateRegisterEndpoint(mFed, "ep1", "")
     epid2 = h.helicsFederateRegisterGlobalEndpoint(mFed, "ep2", "random")
 
@@ -209,10 +203,9 @@ def test_messagefederate_test_message_federate_send(mFed):
 
 
 def test_messagefederate_send_receive_2fed_multisend():
-
-    broker = createBroker(2)
-    mFed1, fedinfo1 = createMessageFederate(1, "A Federate")
-    mFed2, fedinfo2 = createMessageFederate(1, "B Federate")
+    broker = create_broker(2)
+    mFed1, fedinfo1 = create_message_federate(1, "A Federate")
+    mFed2, fedinfo2 = create_message_federate(1, "B Federate")
 
     epid1 = h.helicsFederateRegisterEndpoint(mFed1, "ep1", "")
     epid2 = h.helicsFederateRegisterGlobalEndpoint(mFed2, "ep2", "random")
@@ -253,13 +246,12 @@ def test_messagefederate_send_receive_2fed_multisend():
     # FIXME: Someday this will be implemented.
     # @test_broken h.helicsEndpointGetOption(epid1, h.HELICS_HANDLE_OPTION_IGNORE_INTERRUPTS) is True
 
-    destroyFederate(mFed1, fedinfo1)
-    destroyFederate(mFed2, fedinfo2)
-    destroyBroker(broker)
+    destroy_federate(mFed1, fedinfo1)
+    destroy_federate(mFed2, fedinfo2)
+    destroy_broker(broker)
 
 
 def test_messagefederate_message_object_tests(mFed):
-
     epid1 = h.helicsFederateRegisterEndpoint(mFed, "ep1", "")
     epid2 = h.helicsFederateRegisterGlobalEndpoint(mFed, "ep2", "random")
 
@@ -305,18 +297,21 @@ def test_messagefederate_message_object_tests(mFed):
 
 
 def test_messagefederate_timing_tests():
-
-    broker = createBroker(1)
-    vFed1, fedinfo1 = createMessageFederate(1, "fed0")
-    vFed2, fedinfo2 = createMessageFederate(1, "fed1")
+    broker = create_broker(1)
+    vFed1, fedinfo1 = create_message_federate(1, "fed0")
+    vFed2, fedinfo2 = create_message_federate(1, "fed1")
 
     h.helicsFederateSetTimeProperty(vFed1, h.HELICS_PROPERTY_TIME_PERIOD, 0.1)
     h.helicsFederateSetTimeProperty(vFed2, h.HELICS_PROPERTY_TIME_PERIOD, 0.1)
 
     h.helicsFederateSetTimeProperty(vFed2, h.HELICS_PROPERTY_TIME_INPUT_DELAY, 0.1)
 
-    h.helicsFederateSetFlagOption(vFed1, h.HELICS_FLAG_IGNORE_TIME_MISMATCH_WARNINGS, True)
-    h.helicsFederateSetFlagOption(vFed2, h.HELICS_FLAG_IGNORE_TIME_MISMATCH_WARNINGS, True)
+    h.helicsFederateSetFlagOption(
+        vFed1, h.HELICS_FLAG_IGNORE_TIME_MISMATCH_WARNINGS, True
+    )
+    h.helicsFederateSetFlagOption(
+        vFed2, h.HELICS_FLAG_IGNORE_TIME_MISMATCH_WARNINGS, True
+    )
 
     ept1 = h.helicsFederateRegisterGlobalEndpoint(vFed1, "e1", "")
     h.helicsFederateRegisterGlobalEndpoint(vFed2, "e2", "")
@@ -329,16 +324,38 @@ def test_messagefederate_timing_tests():
     # check that the request is only granted at the appropriate period
     assert gtime == 1.0
 
-    assert h.helicsFederateGetIntegerProperty(vFed1, h.HELICS_PROPERTY_INT_CONSOLE_LOG_LEVEL) == -1
-    assert h.helicsFederateGetIntegerProperty(vFed2, h.HELICS_PROPERTY_INT_CONSOLE_LOG_LEVEL) == -1
+    assert (
+        h.helicsFederateGetIntegerProperty(
+            vFed1, h.HELICS_PROPERTY_INT_CONSOLE_LOG_LEVEL
+        )
+        == -1
+    )
+    assert (
+        h.helicsFederateGetIntegerProperty(
+            vFed2, h.HELICS_PROPERTY_INT_CONSOLE_LOG_LEVEL
+        )
+        == -1
+    )
 
-    assert h.helicsFederateGetFlagOption(vFed1, h.HELICS_FLAG_IGNORE_TIME_MISMATCH_WARNINGS) is True
-    assert h.helicsFederateGetFlagOption(vFed2, h.HELICS_FLAG_IGNORE_TIME_MISMATCH_WARNINGS) is True
+    assert (
+        h.helicsFederateGetFlagOption(
+            vFed1, h.HELICS_FLAG_IGNORE_TIME_MISMATCH_WARNINGS
+        )
+        is True
+    )
+    assert (
+        h.helicsFederateGetFlagOption(
+            vFed2, h.HELICS_FLAG_IGNORE_TIME_MISMATCH_WARNINGS
+        )
+        is True
+    )
 
     h.helicsEndpointSendBytesTo(ept1, "test1".encode(), "e2")
     h.helicsFederateRequestTimeAsync(vFed1, 1.9)
     gtime = h.helicsFederateRequestTimeComplete(vFed2)
-    assert gtime >= 1.1  # the message should show up at the next available time point after the impact window
+    assert (
+        gtime >= 1.1
+    )  # the message should show up at the next available time point after the impact window
     h.helicsFederateRequestTimeAsync(vFed2, 2.0)
     gtime = h.helicsFederateRequestTimeComplete(vFed1)
     assert gtime >= 1.9
@@ -355,6 +372,6 @@ def test_messagefederate_timing_tests():
     h.helicsFederateDisconnect(vFed1)
     h.helicsFederateDisconnect(vFed2)
 
-    destroyFederate(vFed1, fedinfo1)
-    destroyFederate(vFed2, fedinfo2)
-    destroyBroker(broker)
+    destroy_federate(vFed1, fedinfo1)
+    destroy_federate(vFed2, fedinfo2)
+    destroy_broker(broker)

--- a/tests/test_messagefilter.py
+++ b/tests/test_messagefilter.py
@@ -1,20 +1,17 @@
 # -*- coding: utf-8 -*-
-import os
-import sys
-
-CURRENT_DIRECTORY = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
-
-sys.path.append(CURRENT_DIRECTORY)
-sys.path.append(os.path.dirname(CURRENT_DIRECTORY))
-
 import time
 import helics as h
 
-from test_init import createBroker, createValueFederate, destroyFederate, destroyBroker, createMessageFederate
+from .utils import (
+    create_broker,
+    destroy_federate,
+    destroy_broker,
+    create_message_federate,
+)
 
 
 def test_broker():
-    broker = createBroker(1)
+    broker = create_broker(1)
     initstring = "--broker="
     identifier = h.helicsBrokerGetIdentifier(broker)
     initstring = initstring + identifier
@@ -22,15 +19,14 @@ def test_broker():
     address = h.helicsBrokerGetAddress(broker)
     initstring = initstring + address
     assert initstring == "--broker=mainbroker --broker_address tcp://127.0.0.1:23404"
-    destroyBroker(broker)
+    destroy_broker(broker)
 
 
 def test_messagefilter_registration():
+    broker = create_broker(2)
 
-    broker = createBroker(2)
-
-    fFed, ffedinfo = createMessageFederate(1, "filter")
-    mFed, mfedinfo = createMessageFederate(1, "message")
+    fFed, ffedinfo = create_message_federate(1, "filter")
+    mFed, mfedinfo = create_message_federate(1, "message")
 
     h.helicsFederateRegisterGlobalEndpoint(mFed, "port1", "")
     h.helicsFederateRegisterGlobalEndpoint(mFed, "port2", "")
@@ -55,19 +51,18 @@ def test_messagefilter_registration():
     h.helicsFederateDisconnect(mFed)
     h.helicsFederateDisconnect(fFed)
 
-    destroyFederate(fFed, ffedinfo)
-    destroyFederate(mFed, mfedinfo)
+    destroy_federate(fFed, ffedinfo)
+    destroy_federate(mFed, mfedinfo)
     time.sleep(1.0)
 
-    destroyBroker(broker)
+    destroy_broker(broker)
 
 
 def test_messagefilter_info():
+    broker = create_broker(2)
 
-    broker = createBroker(2)
-
-    fFed, ffedinfo = createMessageFederate(1, "filter")
-    mFed, mfedinfo = createMessageFederate(1, "message")
+    fFed, ffedinfo = create_message_federate(1, "filter")
+    mFed, mfedinfo = create_message_federate(1, "message")
 
     p1 = h.helicsFederateRegisterGlobalEndpoint(mFed, "port1", "")
     p2 = h.helicsFederateRegisterGlobalEndpoint(mFed, "port2", "")
@@ -111,28 +106,34 @@ def test_messagefilter_info():
     h.helicsFederateDisconnect(mFed)
     h.helicsFederateDisconnect(fFed)
 
-    destroyFederate(fFed, ffedinfo)
-    destroyFederate(mFed, mfedinfo)
+    destroy_federate(fFed, ffedinfo)
+    destroy_federate(mFed, mfedinfo)
     time.sleep(1.0)
 
-    destroyBroker(broker)
+    destroy_broker(broker)
 
 
 def test_messagefilter_function():
-    broker = createBroker(2)
+    broker = create_broker(2)
 
-    fFed, ffedinfo = createMessageFederate(1, "filter")
-    mFed, mfedinfo = createMessageFederate(1, "message")
+    fFed, ffedinfo = create_message_federate(1, "filter")
+    mFed, mfedinfo = create_message_federate(1, "message")
 
     p1 = h.helicsFederateRegisterGlobalEndpoint(mFed, "port1", "")
     p2 = h.helicsFederateRegisterGlobalEndpoint(mFed, "port2", "random")
 
-    f1 = h.helicsFederateRegisterGlobalFilter(fFed, h.HELICS_FILTER_TYPE_CUSTOM, "filter1")
+    f1 = h.helicsFederateRegisterGlobalFilter(
+        fFed, h.HELICS_FILTER_TYPE_CUSTOM, "filter1"
+    )
     h.helicsFilterAddSourceTarget(f1, "port1")
-    f2 = h.helicsFederateRegisterGlobalFilter(fFed, h.HELICS_FILTER_TYPE_DELAY, "filter2")
+    f2 = h.helicsFederateRegisterGlobalFilter(
+        fFed, h.HELICS_FILTER_TYPE_DELAY, "filter2"
+    )
     h.helicsFilterAddSourceTarget(f2, "port1")
     h.helicsFederateRegisterEndpoint(fFed, "fout", "")
-    f3 = h.helicsFederateRegisterFilter(fFed, h.HELICS_FILTER_TYPE_RANDOM_DELAY, "filter3")
+    f3 = h.helicsFederateRegisterFilter(
+        fFed, h.HELICS_FILTER_TYPE_RANDOM_DELAY, "filter3"
+    )
     h.helicsFilterAddSourceTarget(f3, "filter/fout")
 
     h.helicsFilterSet(f2, "delay", 2.5)
@@ -168,7 +169,7 @@ def test_messagefilter_function():
     # ep1 = h.helicsFederateRegisterEndpoint(fFed, "fout", "")
     # f3 = h.helicsFederateRegisterSourceFilter(fFed, h.helics_custom_filter, "", "filter0/fout")
 
-    destroyFederate(fFed, ffedinfo)
-    destroyFederate(mFed, mfedinfo)
+    destroy_federate(fFed, ffedinfo)
+    destroy_federate(mFed, mfedinfo)
     time.sleep(1.0)
-    destroyBroker(broker)
+    destroy_broker(broker)

--- a/tests/test_pyhelics.py
+++ b/tests/test_pyhelics.py
@@ -1,13 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import os
-import sys
-
-CURRENT_DIRECTORY = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
-
-sys.path.append(CURRENT_DIRECTORY)
-sys.path.append(os.path.dirname(CURRENT_DIRECTORY))
-
 import helics as h
 
 

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -1,46 +1,113 @@
 # -*- coding: utf-8 -*-
 import os
-import sys
-
-CURRENT_DIRECTORY = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
-
-sys.path.append(CURRENT_DIRECTORY)
-sys.path.append(os.path.dirname(CURRENT_DIRECTORY))
-
 import pytest as pt
 import helics as h
 import logging
+
+from .utils import assert_attributes
+
+CURRENT_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
+
+
+DEFAULT_SUB_OPTION_SETTINGS = {
+    h.HelicsHandleOption.CONNECTION_REQUIRED: 0,
+    h.HelicsHandleOption.CONNECTION_OPTIONAL: 0,
+    h.HelicsHandleOption.SINGLE_CONNECTION_ONLY: 0,
+    h.HelicsHandleOption.MULTIPLE_CONNECTIONS_ALLOWED: 1,
+    h.HelicsHandleOption.BUFFER_DATA: 0,
+    h.HelicsHandleOption.RECONNECTABLE: 0,
+    h.HelicsHandleOption.STRICT_TYPE_CHECKING: 0,
+    h.HelicsHandleOption.RECEIVE_ONLY: 0,
+    h.HelicsHandleOption.SOURCE_ONLY: 0,
+    h.HelicsHandleOption.IGNORE_UNIT_MISMATCH: 0,
+    h.HelicsHandleOption.ONLY_TRANSMIT_ON_CHANGE: 0,
+    h.HelicsHandleOption.ONLY_UPDATE_ON_CHANGE: 0,
+    h.HelicsHandleOption.IGNORE_INTERRUPTS: 0,
+    h.HelicsHandleOption.MULTI_INPUT_HANDLING_METHOD: 0,
+    h.HelicsHandleOption.INPUT_PRIORITY_LOCATION: -1,
+    h.HelicsHandleOption.CLEAR_PRIORITY_LIST: 1,
+    h.HelicsHandleOption.CONNECTIONS: 0,
+}
+
+DEFAULT_PUB_OPTION_SETTINGS = {
+    h.HelicsHandleOption.CONNECTION_REQUIRED: 0,
+    h.HelicsHandleOption.CONNECTION_OPTIONAL: 0,
+    h.HelicsHandleOption.SINGLE_CONNECTION_ONLY: 0,
+    h.HelicsHandleOption.MULTIPLE_CONNECTIONS_ALLOWED: 1,
+    h.HelicsHandleOption.BUFFER_DATA: 0,
+    h.HelicsHandleOption.RECONNECTABLE: 0,
+    h.HelicsHandleOption.STRICT_TYPE_CHECKING: 0,
+    h.HelicsHandleOption.RECEIVE_ONLY: 0,
+    h.HelicsHandleOption.SOURCE_ONLY: 0,
+    h.HelicsHandleOption.IGNORE_UNIT_MISMATCH: 0,
+    h.HelicsHandleOption.ONLY_TRANSMIT_ON_CHANGE: 0,
+    h.HelicsHandleOption.ONLY_UPDATE_ON_CHANGE: 0,
+    h.HelicsHandleOption.IGNORE_INTERRUPTS: 0,
+    h.HelicsHandleOption.MULTI_INPUT_HANDLING_METHOD: 0,
+    h.HelicsHandleOption.INPUT_PRIORITY_LOCATION: 0,
+    h.HelicsHandleOption.CLEAR_PRIORITY_LIST: 0,
+    h.HelicsHandleOption.CONNECTIONS: 0,
+}
+
+
+def assert_entries(dict_like, expected: dict):
+    for key, value in expected.items():
+        assert dict_like[key] == value, f"{repr(dict_like)}.{repr(key)} is not {value}"
 
 
 def test_python_api0():
     broker = h.helicsCreateBroker("zmq", "", "-f 1 --name=mainbroker0")
     fedinfo = h.helicsCreateFederateInfo()
-    assert "HelicsFederateInfo()" in repr(fedinfo)
+    assert isinstance(fedinfo, h.HelicsFederateInfo)
     fedinfo.core_name = "TestFederate"
     fedinfo.core_type = "zmq"
     fedinfo.core_init = "-f 1 --broker=mainbroker0 --name=core0"
     mFed = h.helicsCreateCombinationFederate("TestFederate", fedinfo)
 
-    assert (
-        """HelicsCombinationFederate(name = "TestFederate", state = HelicsFederateState.STARTUP, current_time = -9223372036.854776, n_publications = 0, n_subscriptions = 0, n_endpoints = 0, n_filters = 0, n_pending_messages = 0)"""
-        in repr(mFed)
+    assert_attributes(
+        mFed,
+        {
+            "name": "TestFederate",
+            "state": h.HelicsFederateState.STARTUP,
+            "current_time": -9223372036.854776,
+            "n_publications": 0,
+            "n_subscriptions": 0,
+            "n_endpoints": 0,
+            "n_filters": 0,
+            "n_pending_messages": 0,
+        },
     )
 
     _ = mFed.register_endpoint("ep1")
     _ = mFed.register_global_endpoint("ep2")
 
-    pub = mFed.register_publication("publication", h.HELICS_DATA_TYPE_STRING, "custom-units")
-    assert """HelicsPublication(name = "TestFederate/publication", type = "string", units = "custom-units", info = "")""" in repr(pub)
+    pub = mFed.register_publication(
+        "publication", h.HELICS_DATA_TYPE_STRING, "custom-units"
+    )
+    assert_attributes(
+        pub,
+        {
+            "name": "TestFederate/publication",
+            "type": "string",
+            "units": "custom-units",
+            "info": "",
+        },
+    )
 
     sub = mFed.register_subscription("TestFederate/publication", "custom-units")
-    assert (
-        """HelicsInput(name = "_input_3", units = "custom-units", injection_units = "", publication_type = "", type = "", target = "TestFederate/publication", info = "")"""
-        in repr(sub)
+    assert_attributes(
+        sub,
+        {
+            "name": "_input_3",
+            "units": "custom-units",
+            "injection_units": "",
+            "publication_type": "",
+            "type": "",
+            "target": "TestFederate/publication",
+            "info": "",
+        },
     )
-    assert (
-        """{ 'CONNECTION_REQUIRED' = 0, 'CONNECTION_OPTIONAL' = 0, 'SINGLE_CONNECTION_ONLY' = 0, 'MULTIPLE_CONNECTIONS_ALLOWED' = 1, 'BUFFER_DATA' = 0, 'RECONNECTABLE' = 0, 'STRICT_TYPE_CHECKING' = 0, 'RECEIVE_ONLY' = 0, 'SOURCE_ONLY' = 0, 'IGNORE_UNIT_MISMATCH' = 0, 'ONLY_TRANSMIT_ON_CHANGE' = 0, 'ONLY_UPDATE_ON_CHANGE' = 0, 'IGNORE_INTERRUPTS' = 0, 'MULTI_INPUT_HANDLING_METHOD' = 0, 'INPUT_PRIORITY_LOCATION' = -1, 'CLEAR_PRIORITY_LIST' = 1, 'CONNECTIONS' = 0 }"""
-        in repr(sub.option)
-    )
+    assert_entries(sub.option, DEFAULT_SUB_OPTION_SETTINGS)
     sub.option["CONNECTION_REQUIRED"] = 1
     sub.option[h.HELICS_HANDLE_OPTION_CONNECTION_REQUIRED] = 1
     assert sub.option["CONNECTION_REQUIRED"] == 1
@@ -53,42 +120,61 @@ def test_python_api0():
 
     mFed.enter_executing_mode()
 
-    h.helicsCloseLibrary()
-
-    del mFed
-    del broker
-
 
 def test_python_api1():
-
     broker = h.helicsCreateBroker("zmq", "", "-f 1 --name=mainbroker1")
     fedinfo = h.helicsCreateFederateInfo()
-    assert "HelicsFederateInfo()" in repr(fedinfo)
+    assert isinstance(fedinfo, h.HelicsFederateInfo)
     fedinfo.core_name = "TestFederate"
     fedinfo.core_type = "zmq"
     fedinfo.core_init = "-f 1 --broker=mainbroker1  --name=core0"
     mFed = h.helicsCreateCombinationFederate("TestFederate", fedinfo)
 
-    assert (
-        """HelicsCombinationFederate(name = "TestFederate", state = HelicsFederateState.STARTUP, current_time = -9223372036.854776, n_publications = 0, n_subscriptions = 0, n_endpoints = 0, n_filters = 0, n_pending_messages = 0)"""
-        in repr(mFed)
+    assert_attributes(
+        mFed,
+        {
+            "name": "TestFederate",
+            "state": h.HelicsFederateState.STARTUP,
+            "current_time": -9223372036.854776,
+            "n_publications": 0,
+            "n_subscriptions": 0,
+            "n_endpoints": 0,
+            "n_filters": 0,
+            "n_pending_messages": 0,
+        },
     )
 
     _ = mFed.register_endpoint("ep1")
     _ = mFed.register_global_endpoint("ep2")
 
-    pub = mFed.register_publication("publication", h.HELICS_DATA_TYPE_STRING, "custom-units")
-    assert """HelicsPublication(name = "TestFederate/publication", type = "string", units = "custom-units", info = "")""" in repr(pub)
+    pub = mFed.register_publication(
+        "publication", h.HELICS_DATA_TYPE_STRING, "custom-units"
+    )
+    assert_attributes(
+        pub,
+        {
+            "name": "TestFederate/publication",
+            "type": "string",
+            "units": "custom-units",
+            "info": "",
+        },
+    )
 
     sub = mFed.register_subscription("TestFederate/publication", "custom-units")
-    assert (
-        """HelicsInput(name = "_input_3", units = "custom-units", injection_units = "", publication_type = "", type = "", target = "TestFederate/publication", info = "")"""
-        in repr(sub)
+    assert_attributes(
+        sub,
+        {
+            "name": "_input_3",
+            "units": "custom-units",
+            "injection_units": "",
+            "publication_type": "",
+            "type": "",
+            "target": "TestFederate/publication",
+            "info": "",
+        },
     )
-    assert (
-        """{ 'CONNECTION_REQUIRED' = 0, 'CONNECTION_OPTIONAL' = 0, 'SINGLE_CONNECTION_ONLY' = 0, 'MULTIPLE_CONNECTIONS_ALLOWED' = 1, 'BUFFER_DATA' = 0, 'RECONNECTABLE' = 0, 'STRICT_TYPE_CHECKING' = 0, 'RECEIVE_ONLY' = 0, 'SOURCE_ONLY' = 0, 'IGNORE_UNIT_MISMATCH' = 0, 'ONLY_TRANSMIT_ON_CHANGE' = 0, 'ONLY_UPDATE_ON_CHANGE' = 0, 'IGNORE_INTERRUPTS' = 0, 'MULTI_INPUT_HANDLING_METHOD' = 0, 'INPUT_PRIORITY_LOCATION' = -1, 'CLEAR_PRIORITY_LIST' = 1, 'CONNECTIONS' = 0 }"""
-        in repr(sub.option)
-    )
+
+    assert_entries(sub.option, DEFAULT_SUB_OPTION_SETTINGS)
     sub.option["CONNECTION_REQUIRED"] = 1
     assert sub.option["CONNECTION_REQUIRED"] == 1
 
@@ -120,12 +206,14 @@ def test_python_api1():
     sub.info = "hello world"
     assert sub.info == "hello world"
 
-    assert (
-        """{ 'CONNECTION_REQUIRED' = 0, 'CONNECTION_OPTIONAL' = 0, 'SINGLE_CONNECTION_ONLY' = 0, 'MULTIPLE_CONNECTIONS_ALLOWED' = 1, 'BUFFER_DATA' = 0, 'RECONNECTABLE' = 0, 'STRICT_TYPE_CHECKING' = 0, 'RECEIVE_ONLY' = 0, 'SOURCE_ONLY' = 0, 'IGNORE_UNIT_MISMATCH' = 0, 'ONLY_TRANSMIT_ON_CHANGE' = 0, 'ONLY_UPDATE_ON_CHANGE' = 0, 'IGNORE_INTERRUPTS' = 0, 'MULTI_INPUT_HANDLING_METHOD' = 0, 'INPUT_PRIORITY_LOCATION' = 0, 'CLEAR_PRIORITY_LIST' = 0, 'CONNECTIONS' = 0 }"""
-        in repr(mFed.publications["TestFederate/publication"].option)
+    assert_entries(
+        mFed.publications["TestFederate/publication"].option,
+        DEFAULT_PUB_OPTION_SETTINGS,
     )
     mFed.publications["TestFederate/publication"].option["CONNECTION_REQUIRED"] = 1
-    assert mFed.publications["TestFederate/publication"].option["CONNECTION_REQUIRED"] == 1
+    assert (
+        mFed.publications["TestFederate/publication"].option["CONNECTION_REQUIRED"] == 1
+    )
 
     mFed.enter_executing_mode()
 
@@ -159,19 +247,20 @@ def test_python_api1():
 
     message = mFed.endpoints["ep2"].get_message()
 
-    assert message.message_id == 55
     assert message.is_valid() is True
-    assert message.data == "random-data"
-    assert message.raw_data == b"random-data"
-    assert len(message.raw_data) == 11
-    assert message.original_destination == ""
-    assert message.original_source == "TestFederate/ep1"
-    assert message.source == "TestFederate/ep1"
-    assert message.time == 1.0
 
-    assert (
-        """HelicsMessage(source = "TestFederate/ep1", destination = "ep2", original_source = "TestFederate/ep1", original_destination = "", time = 1.0, id = 55, message = "random-data")"""
-        in repr(message)
+    assert_attributes(
+        message,
+        {
+            "source": "TestFederate/ep1",
+            "destination": "ep2",
+            "original_source": "TestFederate/ep1",
+            "original_destination": "",
+            "time": 1.0,
+            "message_id": 55,
+            "data": "random-data",
+            "raw_data": b"random-data",
+        },
     )
 
     message.append("-random")
@@ -201,10 +290,8 @@ def test_python_api1():
     assert message.time == 2.0
 
     assert message.is_valid() is True
-    assert (
-        """<{ 1 = False, 2 = False, 3 = False, 4 = False, 5 = False, 6 = False, 7 = False, 8 = False, 9 = False, 10 = False, 11 = False, 12 = False, 13 = False, 14 = False, 15 = False }>"""
-        in repr(message.flag)
-    )
+    # TODO(josephmckinsey): This will probably fail
+    assert_entries(message.flag, {i: False for i in range(1, 16)})
     assert message.is_valid() is True
     message.flag[1] = True
     assert message.flag[1] is True
@@ -245,28 +332,41 @@ def test_python_api1():
 
     assert mFed.subscriptions["TestFederate/publication"].boolean is False
     m = mFed.create_message()
-    assert (
-        """HelicsMessage(source = "", destination = "", original_source = "", original_destination = "", time = 0.0, id = 0, message = "")"""
-        in repr(m)
+    assert_attributes(
+        m,
+        {
+            "source": "",
+            "destination": "",
+            "original_source": "",
+            "original_destination": "",
+            "time": 0.0,
+            "data": "",
+            "message_id": 0,
+        },
     )
     mFed.info = "hello-world"
     assert mFed.info == "hello-world"
 
     m = mFed.endpoints["ep2"].create_message()
-    assert (
-        """HelicsMessage(source = "", destination = "", original_source = "", original_destination = "", time = 0.0, id = 0, message = "")"""
-        in repr(m)
+    assert_attributes(
+        m,
+        {
+            "source": "",
+            "destination": "",
+            "original_source": "",
+            "original_destination": "",
+            "time": 0.0,
+            "data": "",
+            "message_id": 0,
+        },
     )
-
     mFed.disconnect()
-
-    del mFed
-    del broker
 
 
 def test_python_api2():
-
-    broker = h.helicsCreateBroker("zmq", "broker", "--federates 1 --loglevel=warning  --name=mainbroker2")
+    broker = h.helicsCreateBroker(
+        "zmq", "broker", "--federates 1 --loglevel=warning  --name=mainbroker2"
+    )
     assert broker.is_connected()
 
     broker.set_global("hello", "world")
@@ -277,7 +377,9 @@ def test_python_api2():
     try:
         assert broker.query("hello", "world") == "#invalid"
     except AssertionError:
-        assert broker.query("hello", "world") == {"error": {"code": 404, "message": "query not valid"}}
+        assert broker.query("hello", "world") == {
+            "error": {"code": 404, "message": "query not valid"}
+        }
 
     fi = h.helicsCreateFederateInfo()
     fi.core_init = "--federates 1 --brokername=mainbroker2 --name=core2"
@@ -285,16 +387,17 @@ def test_python_api2():
 
     fed = h.helicsCreateCombinationFederate("test1", fi)
 
-    assert "HelicsCore" in repr(fed.core)
-    assert 'address = "tcp://127.0.0.1' in repr(fed.core)
+    assert isinstance(fed.core, h.HelicsCore)
+    # assert ignores port intentionally
+    assert "tcp://127.0.0.1" in fed.core.address
 
     assert fed.core.is_connected()
     fed.core.set_ready_to_init()
 
-    assert "n_publications = 0" in repr(fed)
-    assert "n_subscriptions = 0" in repr(fed)
-    assert "n_endpoints = 0" in repr(fed)
-    assert "n_filters = 0" in repr(fed)
+    assert_attributes(
+        fed,
+        {"n_publications": 0, "n_subscriptions": 0, "n_endpoints": 0, "n_filters": 0},
+    )
 
     assert fed.property["DELTA"] == 1e-09
     assert fed.property["PERIOD"] == 0.0
@@ -343,19 +446,6 @@ def test_python_api2():
     assert fed.property[h.HelicsProperty.INT_FILE_LOG_LEVEL.value] == 5
     assert fed.property[h.HelicsProperty.INT_CONSOLE_LOG_LEVEL.value] == 5
 
-    assert "'TIME_DELTA' = 1e-09" in repr(fed.property)
-    assert "'TIME_PERIOD' = 0.0" in repr(fed.property)
-    assert "'TIME_OFFSET' = 0.0" in repr(fed.property)
-    assert "'TIME_RT_LAG' = 0.0" in repr(fed.property)
-    assert "'TIME_RT_LEAD' = 0.0" in repr(fed.property)
-    assert "'TIME_RT_TOLERANCE' = 0.0" in repr(fed.property)
-    assert "'TIME_INPUT_DELAY' = 0.0" in repr(fed.property)
-    assert "'TIME_OUTPUT_DELAY' = 0.0" in repr(fed.property)
-    assert "'INT_MAX_ITERATIONS' = 50" in repr(fed.property)
-    assert "'INT_LOG_LEVEL' = 5" in repr(fed.property)
-    assert "'INT_FILE_LOG_LEVEL' = 5" in repr(fed.property)
-    assert "'INT_CONSOLE_LOG_LEVEL' = 5" in repr(fed.property)
-
     assert fed.flag[h.HELICS_FLAG_OBSERVER] is False
     assert fed.flag[h.HELICS_FLAG_UNINTERRUPTIBLE] is False
     assert fed.flag[h.HELICS_FLAG_INTERRUPTIBLE] is True
@@ -385,19 +475,6 @@ def test_python_api2():
     assert fed.flag[h.HELICS_FLAG_IGNORE_TIME_MISMATCH_WARNINGS.value] is False
     assert fed.flag[h.HELICS_FLAG_TERMINATE_ON_ERROR.value] is False
 
-    assert "'OBSERVER' = False" in repr(fed.flag)
-    assert "'UNINTERRUPTIBLE' = False" in repr(fed.flag)
-    assert "'INTERRUPTIBLE' = True" in repr(fed.flag)
-    assert "'SOURCE_ONLY' = False" in repr(fed.flag)
-    assert "'ONLY_TRANSMIT_ON_CHANGE' = False" in repr(fed.flag)
-    assert "'ONLY_UPDATE_ON_CHANGE' = False" in repr(fed.flag)
-    assert "'WAIT_FOR_CURRENT_TIME_UPDATE' = False" in repr(fed.flag)
-    assert "'RESTRICTIVE_TIME_POLICY' = False" in repr(fed.flag)
-    assert "'REALTIME' = False" in repr(fed.flag)
-    assert "'SLOW_RESPONDING' = False," in repr(fed.flag)
-    assert "'IGNORE_TIME_MISMATCH_WARNINGS' = False," in repr(fed.flag)
-    assert "'TERMINATE_ON_ERROR' = False" in repr(fed.flag)
-
     fed.flag[h.HELICS_FLAG_TERMINATE_ON_ERROR] = True
 
     assert fed.flag[h.HELICS_FLAG_TERMINATE_ON_ERROR] is True
@@ -416,7 +493,9 @@ def test_python_api2():
     try:
         assert fed.core.query("broker", "something") == "#invalid"
     except AssertionError:
-        assert fed.core.query("broker", "something") == {"error": {"code": 400, "message": "unrecognized broker query"}}
+        assert fed.core.query("broker", "something") == {
+            "error": {"code": 400, "message": "unrecognized broker query"}
+        }
 
     fed.add_dependency("hello")
 
@@ -424,33 +503,31 @@ def test_python_api2():
 
     assert fed.core.wait_for_disconnect()
 
-    del fed
-
     broker.disconnect()
     assert broker.wait_for_disconnect()
-
-    del broker
-
-    h.helicsCleanupLibrary()
-    h.helicsCloseLibrary()
 
 
 def test_python_api3():
     core1 = h.helicsCreateCore("inproc", "core3", "--autobroker")
 
-    assert """HelicsCore(identifier = "core3", address = "core3")""" in repr(core1)
+    assert_attributes(core1, {"identifier": "core3", "address": "core3"})
 
     core2 = core1.clone()
 
     assert core1.identifier == "core3"
 
-    source_filter1 = core1.register_filter(h.HELICS_FILTER_TYPE_DELAY, "core3SourceFilter")
+    source_filter1 = core1.register_filter(
+        h.HELICS_FILTER_TYPE_DELAY, "core3SourceFilter"
+    )
 
     source_filter1.add_source_target("ep1")
 
-    assert (
-        """<{ 'CONNECTION_REQUIRED' = 0, 'CONNECTION_OPTIONAL' = 0, 'SINGLE_CONNECTION_ONLY' = 0, 'MULTIPLE_CONNECTIONS_ALLOWED' = 0, 'BUFFER_DATA' = 0, 'RECONNECTABLE' = 0, 'STRICT_TYPE_CHECKING' = 0, 'RECEIVE_ONLY' = 0, 'SOURCE_ONLY' = 0, 'IGNORE_UNIT_MISMATCH' = 0, 'ONLY_TRANSMIT_ON_CHANGE' = 0, 'ONLY_UPDATE_ON_CHANGE' = 0, 'IGNORE_INTERRUPTS' = 0, 'MULTI_INPUT_HANDLING_METHOD' = 0, 'INPUT_PRIORITY_LOCATION' = 0, 'CLEAR_PRIORITY_LIST' = 0, 'CONNECTIONS' = 0 }>"""
-        in repr(source_filter1.option)
+    assert_entries(
+        source_filter1.option,
+        {
+            **DEFAULT_PUB_OPTION_SETTINGS,
+            h.HelicsHandleOption.MULTIPLE_CONNECTIONS_ALLOWED: 0,
+        },
     )
 
     source_filter1.option["CONNECTION_REQUIRED"] = 1
@@ -465,7 +542,9 @@ def test_python_api3():
 
     source_filter1.set("hello", 1)
 
-    destination_filter1 = core1.register_filter(h.HELICS_FILTER_TYPE_DELAY, "core1DestinationFilter")
+    destination_filter1 = core1.register_filter(
+        h.HELICS_FILTER_TYPE_DELAY, "core1DestinationFilter"
+    )
 
     destination_filter1.add_destination_target("ep2")
     cloning_filter1 = core1.register_cloning_filter("ep3")
@@ -479,11 +558,6 @@ def test_python_api3():
 
     core1.disconnect()
     core2.disconnect()
-
-    del core1
-    del core2
-
-    h.helicsCloseLibrary()
 
 
 def test_python_api4():
@@ -512,18 +586,10 @@ def test_python_api5():
         fed.register_interfaces("unknownfile.json")
 
     fed.core.disconnect()
-
     assert fed.core.wait_for_disconnect()
-
-    del fed
 
     broker.disconnect()
     assert broker.wait_for_disconnect()
-
-    del broker
-
-    h.helicsCleanupLibrary()
-    h.helicsCloseLibrary()
 
 
 def test_python_api6():
@@ -537,14 +603,9 @@ def test_python_api6():
 
     fed.core.disconnect()
     assert fed.core.wait_for_disconnect()
-    del fed
 
     broker.disconnect()
     assert broker.wait_for_disconnect()
-    del broker
-
-    h.helicsCleanupLibrary()
-    h.helicsCloseLibrary()
 
 
 @pt.mark.skip(reason="Fails to pass on windows and linux")
@@ -556,7 +617,10 @@ def test_python_api7():
 
     _ = fed.register_filter(h.HELICS_FILTER_TYPE_DELAY, "core1SourceFilter")
 
-    assert fed.get_filter_by_name("core1SourceFilter").name == fed.get_filter_by_index(0).name
+    assert (
+        fed.get_filter_by_name("core1SourceFilter").name
+        == fed.get_filter_by_index(0).name
+    )
 
     fed.set_global("hello", "world")
 
@@ -584,7 +648,9 @@ def test_python_api7():
     try:
         assert fed.query("hello", "world") == "#disconnected"
     except AssertionError:
-        assert fed.query("hello", "world") == {"error": {"code": 404, "message": "query not valid"}}
+        assert fed.query("hello", "world") == {
+            "error": {"code": 404, "message": "query not valid"}
+        }
 
     fed.local_error(0, "local")
     fed.global_error(0, "global")
@@ -600,21 +666,17 @@ def test_python_api7():
 
     fed.core.disconnect()
     assert fed.core.wait_for_disconnect()
-    del fed
 
     broker.disconnect()
     assert broker.wait_for_disconnect()
-    del broker
-
-    h.helicsCleanupLibrary()
-    h.helicsCloseLibrary()
 
 
 def test_python_api8():
-
     broker = h.helicsCreateBroker("zmq", "", "-f 1 --name=mainbroker8")
 
-    cfed = h.helicsCreateCombinationFederateFromConfig(os.path.join(CURRENT_DIRECTORY, "combinationfederate.json"))
+    cfed = h.helicsCreateCombinationFederateFromConfig(
+        os.path.join(CURRENT_DIRECTORY, "combinationfederate.json")
+    )
 
     assert len(cfed.endpoints) == 2
     assert len(cfed.subscriptions) == 2
@@ -622,20 +684,20 @@ def test_python_api8():
     h.helicsFederateDestroy(cfed)
     h.helicsFederateFree(cfed)
     h.helicsBrokerDestroy(broker)
-    h.helicsCloseLibrary()
 
 
 def test_python_api9():
-
     broker = h.helicsCreateBroker("zmq", "", "-f 1 --name=mainbroker")
     fedinfo = h.helicsCreateFederateInfo()
-    assert "HelicsFederateInfo()" in repr(fedinfo)
+    assert isinstance(fedinfo, h.HelicsFederateInfo)
     fedinfo.core_name = "TestFederate"
     fedinfo.core_type = "zmq"
     fedinfo.core_init = "-f 1 --broker=mainbroker"
     mFed = h.helicsCreateCombinationFederate("TestFederate", fedinfo)
 
-    pub = mFed.register_publication("publication", h.HELICS_DATA_TYPE_COMPLEX_VECTOR, "custom-units")
+    pub = mFed.register_publication(
+        "publication", h.HELICS_DATA_TYPE_COMPLEX_VECTOR, "custom-units"
+    )
     assert pub.type == "complex_vector"
 
     sub = mFed.register_subscription("TestFederate/publication", "custom-units")
@@ -647,6 +709,3 @@ def test_python_api9():
     print(sub.value)
 
     mFed.disconnect()
-
-    del mFed
-    del broker

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,23 +1,18 @@
 # -*- coding: utf-8 -*-
-import os
-import sys
-
-CURRENT_DIRECTORY = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
-
-sys.path.append(CURRENT_DIRECTORY)
-sys.path.append(os.path.dirname(CURRENT_DIRECTORY))
-
-import time
 import helics as h
 
-from test_init import createBroker, createValueFederate, destroyFederate, destroyBroker, createMessageFederate
+from .utils import (
+    create_broker,
+    create_value_federate,
+    destroy_federate,
+    destroy_broker,
+)
 
 
 def test_query_federate_tests():
-
-    broker = createBroker(2)
-    vFed1, fedinfo1 = createValueFederate(1, "fed0")
-    vFed2, fedinfo2 = createValueFederate(1, "fed1")
+    broker = create_broker(2)
+    vFed1, fedinfo1 = create_value_federate(1, "fed0")
+    vFed2, fedinfo2 = create_value_federate(1, "fed1")
 
     h.helicsFederateRegisterGlobalTypePublication(vFed1, "pub1", "double", "")
     h.helicsFederateRegisterTypePublication(vFed1, "pub2", "double", "")
@@ -53,16 +48,15 @@ def test_query_federate_tests():
     h.helicsFederateDisconnect(vFed2)
     h.helicsFederateDisconnectComplete(vFed1)
 
-    destroyFederate(vFed1, fedinfo1)
-    destroyFederate(vFed2, fedinfo2)
-    destroyBroker(broker)
+    destroy_federate(vFed1, fedinfo1)
+    destroy_federate(vFed2, fedinfo2)
+    destroy_broker(broker)
 
 
 def test_query_broker_tests():
-
-    broker = createBroker(2)
-    vFed1, fedinfo1 = createValueFederate(1, "fed0")
-    vFed2, fedinfo2 = createValueFederate(1, "fed1")
+    broker = create_broker(2)
+    vFed1, fedinfo1 = create_value_federate(1, "fed0")
+    vFed2, fedinfo2 = create_value_federate(1, "fed1")
     core = h.helicsFederateGetCore(vFed1)
 
     q1 = h.helicsCreateQuery("root", "federates")
@@ -90,6 +84,6 @@ def test_query_broker_tests():
     h.helicsFederateDisconnect(vFed2)
     h.helicsFederateDisconnectComplete(vFed1)
 
-    destroyFederate(vFed1, fedinfo1)
-    destroyFederate(vFed2, fedinfo2)
-    destroyBroker(broker)
+    destroy_federate(vFed1, fedinfo1)
+    destroy_federate(vFed2, fedinfo2)
+    destroy_broker(broker)

--- a/tests/test_systemtests.py
+++ b/tests/test_systemtests.py
@@ -1,20 +1,8 @@
 # -*- coding: utf-8 -*-
 import os
-import sys
-
-CURRENT_DIRECTORY = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
-
-sys.path.append(CURRENT_DIRECTORY)
-sys.path.append(os.path.dirname(CURRENT_DIRECTORY))
-
 import time
 import helics as h
-import pytest
 import pytest as pt
-
-from test_init import createBroker, createValueFederate, destroyFederate, destroyBroker, createMessageFederate
-
-import os
 
 
 def rm(filename, force=True):
@@ -32,11 +20,9 @@ def broker():
     yield brk
     h.helicsBrokerDisconnect(brk)
     assert h.helicsBrokerIsConnected(brk) == False
-    h.helicsCloseLibrary()
 
 
 def test_other_tests_broker_creation():
-
     argv = ["--root"]
 
     brk = h.helicsCreateBrokerFromArgs("zmq", "gbrokerc", argv)
@@ -71,14 +57,15 @@ def test_federate_info_tests_set_broker_init_string():
 
 
 def test_other_tests_core_creation(broker):
-
     cr = h.helicsCreateCoreFromArgs("zmq", "gcore", ["--broker=gbrokertest"])
 
     assert h.helicsCoreGetIdentifier(cr) == "gcore"
 
     # TODO: why is this not raising an exception?
     with pt.raises(h.HelicsException):
-        cr2 = h.helicsCreateCoreFromArgs("test", "gcore2", ["--broker=gbrokerc", "--log-level=what_logs?"])
+        cr2 = h.helicsCreateCoreFromArgs(
+            "test", "gcore2", ["--broker=gbrokerc", "--log-level=what_logs?"]
+        )
 
     h.helicsCoreDisconnect(cr)
 
@@ -103,7 +90,6 @@ def test_system_broker_global_value():
 
 
 def test_system_test_core_global_value1():
-
     brk = h.helicsCreateBroker("zmq", "gbrokerc", "--root")
     cr = h.helicsCreateCore("zmq", "gcore", "--broker=gbrokerc")
 
@@ -123,10 +109,9 @@ def test_system_test_core_global_value1():
     h.helicsBrokerDisconnect(brk)
 
     assert h.helicsBrokerIsConnected(brk) is False
-    h.helicsCloseLibrary()
 
 
-@pt.mark.skip(reason = "Segfaults on linux")
+@pt.mark.skip(reason="Segfaults on linux")
 def test_system_test_core_global_value2():
     brk = h.helicsCreateBroker("zmq", "gbrokerc", "--root")
 
@@ -153,7 +138,6 @@ def test_system_test_core_global_value2():
 
 
 def test_system_test_broker_global_value():
-
     brk = h.helicsCreateBroker("inproc", "gbroker", "--root")
     globalVal = "this is a string constant that functions as a global"
     globalVal2 = "this is a second string constant that functions as a global"
@@ -175,7 +159,6 @@ def test_system_test_broker_global_value():
 
 
 def test_system_test_federate_global_value():
-
     brk = h.helicsCreateBroker("inproc", "gbrokerc", "--root")
     cr = h.helicsCreateCore("inproc", "gcore", "--broker=gbrokerc")
 
@@ -226,7 +209,6 @@ def test_system_test_federate_global_value():
     h.helicsCoreDisconnect(cr)
 
     assert h.helicsBrokerIsConnected(brk) is False
-    h.helicsCloseLibrary()
 
 
 def test_system_tests_core_logging():
@@ -252,7 +234,6 @@ def test_system_tests_broker_logging():
 
 
 def test_system_tests_federate_logging():
-
     lfile = "log.txt"
     rm(lfile, force=True)
     core = h.helicsCreateCore("inproc", "clogf", "--autobroker --log_level=trace")
@@ -278,7 +259,6 @@ def test_system_tests_federate_logging():
 
 
 def test_federate_tests_federateGeneratedLocalError():
-
     brk = h.helicsCreateBroker("inproc", "gbrokerc", "--root")
     cr = h.helicsCreateCore("inproc", "gcore", "--broker=gbrokerc")
 
@@ -301,11 +281,9 @@ def test_federate_tests_federateGeneratedLocalError():
     h.helicsFederateDestroy(fed1)
     h.helicsCoreDisconnect(cr)
     h.helicsBrokerDisconnect(brk)
-    h.helicsCloseLibrary()
 
 
 def test_federate_tests_federateGeneratedGlobalError():
-
     brk = h.helicsCreateBroker("inproc", "gbrokerc", "--root")
     cr = h.helicsCreateCore("inproc", "gcore", "--broker=gbrokerc")
 
@@ -328,4 +306,3 @@ def test_federate_tests_federateGeneratedGlobalError():
     h.helicsFederateDestroy(fed1)
     h.helicsCoreDisconnect(cr)
     h.helicsBrokerDisconnect(brk)
-    h.helicsCloseLibrary()

--- a/tests/test_valuefederate.py
+++ b/tests/test_valuefederate.py
@@ -1,34 +1,28 @@
 # -*- coding: utf-8 -*-
 import os
-import sys
-
-CURRENT_DIRECTORY = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
-
-sys.path.append(CURRENT_DIRECTORY)
-sys.path.append(os.path.dirname(CURRENT_DIRECTORY))
-
-import time
 import helics as h
-import os
-import pytest as pt
 
-from test_init import createBroker, createValueFederate, destroyFederate, destroyBroker, createMessageFederate
+from .utils import (
+    create_broker,
+    create_value_federate,
+    destroy_federate,
+    destroy_broker,
+)
 
 
 CURRENT_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
 
 
 def test_valuefederate_creation():
-    broker = createBroker()
-    vFed, fedinfo = createValueFederate()
-    destroyFederate(vFed, fedinfo)
-    destroyBroker(broker)
+    broker = create_broker()
+    vFed, fedinfo = create_value_federate()
+    destroy_federate(vFed, fedinfo)
+    destroy_broker(broker)
 
 
 def test_valuefederate_state():
-
-    broker = createBroker()
-    vFed, fedinfo = createValueFederate()
+    broker = create_broker()
+    vFed, fedinfo = create_value_federate()
 
     state = h.helicsFederateGetState(vFed)
     assert state == 0
@@ -38,13 +32,13 @@ def test_valuefederate_state():
     state = h.helicsFederateGetState(vFed)
     assert state == 2
 
-    destroyFederate(vFed, fedinfo)
-    destroyBroker(broker)
+    destroy_federate(vFed, fedinfo)
+    destroy_broker(broker)
 
 
 def test_valuefederate_publication_registration():
-    broker = createBroker()
-    vFed, fedinfo = createValueFederate()
+    broker = create_broker()
+    vFed, fedinfo = create_value_federate()
 
     pubid1 = h.helicsFederateRegisterTypePublication(vFed, "pub1", "string", "")
     pubid2 = h.helicsFederateRegisterGlobalTypePublication(vFed, "pub2", "int", "")
@@ -59,13 +53,13 @@ def test_valuefederate_publication_registration():
     assert h.helicsPublicationGetType(pubid3) == "double"
     assert h.helicsPublicationGetUnits(pubid3) == "V"
 
-    destroyFederate(vFed, fedinfo)
-    destroyBroker(broker)
+    destroy_federate(vFed, fedinfo)
+    destroy_broker(broker)
 
 
 def test_valuefederate_named_point():
-    broker = createBroker()
-    vFed, fedinfo = createValueFederate()
+    broker = create_broker()
+    vFed, fedinfo = create_value_federate()
 
     defaultValue = "start of a longer string in place of the shorter one and now this should be very long"
     defVal = 5.3
@@ -75,7 +69,9 @@ def test_valuefederate_named_point():
     testValue2 = "I am a string"
     testVal2 = 0.0
 
-    pubid = h.helicsFederateRegisterGlobalPublication(vFed, "pub1", h.HELICS_DATA_TYPE_NAMED_POINT, "")
+    pubid = h.helicsFederateRegisterGlobalPublication(
+        vFed, "pub1", h.HELICS_DATA_TYPE_NAMED_POINT, ""
+    )
     subid = h.helicsFederateRegisterSubscription(vFed, "pub1", "")
 
     h.helicsInputSetDefaultNamedPoint(subid, defaultValue, defVal)
@@ -107,20 +103,22 @@ def test_valuefederate_named_point():
     # # make sure the value was updated
     assert h.helicsInputGetNamedPoint(subid) == (testValue2, testVal2)
 
-    destroyFederate(vFed, fedinfo)
-    destroyBroker(broker)
+    destroy_federate(vFed, fedinfo)
+    destroy_broker(broker)
 
 
 def test_valuefederate_test_bool():
-    broker = createBroker()
-    vFed, fedinfo = createValueFederate()
+    broker = create_broker()
+    vFed, fedinfo = create_value_federate()
 
     defaultValue = True
     testValue1 = True
     testValue2 = False
 
     # register the publications
-    pubid = h.helicsFederateRegisterGlobalPublication(vFed, "pub1", h.HELICS_DATA_TYPE_BOOLEAN, "")
+    pubid = h.helicsFederateRegisterGlobalPublication(
+        vFed, "pub1", h.HELICS_DATA_TYPE_BOOLEAN, ""
+    )
     subid = h.helicsFederateRegisterSubscription(vFed, "pub1", "")
 
     h.helicsInputSetDefaultBoolean(subid, defaultValue)
@@ -156,17 +154,23 @@ def test_valuefederate_test_bool():
     val = h.helicsInputGetBoolean(subid)
     assert val == testValue2
 
-    destroyFederate(vFed, fedinfo)
-    destroyBroker(broker)
+    destroy_federate(vFed, fedinfo)
+    destroy_broker(broker)
 
 
 def test_valuefederate_publisher_registration():
-    broker = createBroker()
-    vFed, fedinfo = createValueFederate()
+    broker = create_broker()
+    vFed, fedinfo = create_value_federate()
 
-    pubid1 = h.helicsFederateRegisterPublication(vFed, "pub1", h.HELICS_DATA_TYPE_STRING, "")
-    pubid2 = h.helicsFederateRegisterGlobalPublication(vFed, "pub2", h.HELICS_DATA_TYPE_INT, "")
-    pubid3 = h.helicsFederateRegisterPublication(vFed, "pub3", h.HELICS_DATA_TYPE_DOUBLE, "V")
+    pubid1 = h.helicsFederateRegisterPublication(
+        vFed, "pub1", h.HELICS_DATA_TYPE_STRING, ""
+    )
+    pubid2 = h.helicsFederateRegisterGlobalPublication(
+        vFed, "pub2", h.HELICS_DATA_TYPE_INT, ""
+    )
+    pubid3 = h.helicsFederateRegisterPublication(
+        vFed, "pub3", h.HELICS_DATA_TYPE_DOUBLE, "V"
+    )
     h.helicsFederateEnterExecutingMode(vFed)
 
     publication_key = h.helicsPublicationGetName(pubid1)
@@ -184,17 +188,20 @@ def test_valuefederate_publisher_registration():
     publication_type = h.helicsPublicationGetType(pubid2)
     assert publication_type == "int64"
 
-    destroyFederate(vFed, fedinfo)
-    destroyBroker(broker)
+    destroy_federate(vFed, fedinfo)
+    destroy_broker(broker)
 
 
 def test_valuefederate_subscription_and_publication_registration():
+    broker = create_broker()
+    vFed, fedinfo = create_value_federate(1, "fed0")
 
-    broker = createBroker()
-    vFed, fedinfo = createValueFederate(1, "fed0")
-
-    pubid = h.helicsFederateRegisterPublication(vFed, "pub1", h.HELICS_DATA_TYPE_STRING, "")
-    pubid2 = h.helicsFederateRegisterGlobalPublication(vFed, "pub2", h.HELICS_DATA_TYPE_INT, "volts")
+    pubid = h.helicsFederateRegisterPublication(
+        vFed, "pub1", h.HELICS_DATA_TYPE_STRING, ""
+    )
+    pubid2 = h.helicsFederateRegisterGlobalPublication(
+        vFed, "pub2", h.HELICS_DATA_TYPE_INT, "volts"
+    )
     pubid3 = h.helicsFederateRegisterTypePublication(vFed, "pub3", "double", "V")
 
     subid1 = h.helicsFederateRegisterSubscription(vFed, "sub1", "")
@@ -260,16 +267,17 @@ def test_valuefederate_subscription_and_publication_registration():
     state = h.helicsFederateGetState(vFed)
     assert state == h.HELICS_STATE_FINALIZE
 
-    destroyFederate(vFed, fedinfo)
-    destroyBroker(broker)
+    destroy_federate(vFed, fedinfo)
+    destroy_broker(broker)
 
 
 def test_valuefederate_single_transfer():
+    broker = create_broker()
+    vFed, fedinfo = create_value_federate()
 
-    broker = createBroker()
-    vFed, fedinfo = createValueFederate()
-
-    pubid = h.helicsFederateRegisterGlobalPublication(vFed, "pub1", h.HELICS_DATA_TYPE_STRING, "")
+    pubid = h.helicsFederateRegisterGlobalPublication(
+        vFed, "pub1", h.HELICS_DATA_TYPE_STRING, ""
+    )
     subid = h.helicsFederateRegisterSubscription(vFed, "pub1", "")
 
     h.helicsFederateEnterExecutingMode(vFed)
@@ -282,17 +290,19 @@ def test_valuefederate_single_transfer():
     s = h.helicsInputGetString(subid)
     assert s == "string1"
 
-    destroyFederate(vFed, fedinfo)
-    destroyBroker(broker)
+    destroy_federate(vFed, fedinfo)
+    destroy_broker(broker)
 
 
 def test_valuefederate_test_double():
-    broker = createBroker()
-    vFed, fedinfo = createValueFederate()
+    broker = create_broker()
+    vFed, fedinfo = create_value_federate()
 
     defaultValue = 1.0
     testValue = 2.0
-    pubid = h.helicsFederateRegisterGlobalPublication(vFed, "pub1", h.HELICS_DATA_TYPE_DOUBLE, "")
+    pubid = h.helicsFederateRegisterGlobalPublication(
+        vFed, "pub1", h.HELICS_DATA_TYPE_DOUBLE, ""
+    )
     subid = h.helicsFederateRegisterSubscription(vFed, "pub1", "")
     h.helicsInputSetDefaultDouble(subid, defaultValue)
 
@@ -319,19 +329,21 @@ def test_valuefederate_test_double():
     value = h.helicsInputGetDouble(subid)
     assert value == testValue + 1
 
-    destroyFederate(vFed, fedinfo)
-    destroyBroker(broker)
+    destroy_federate(vFed, fedinfo)
+    destroy_broker(broker)
 
 
 def test_valuefederate_test_complex():
-    broker = createBroker()
-    vFed, fedinfo = createValueFederate()
+    broker = create_broker()
+    vFed, fedinfo = create_value_federate()
 
     rDefaultValue = 1.0
     iDefaultValue = 1.0
     rTestValue = 2.0
     iTestValue = 2.0
-    pubid = h.helicsFederateRegisterGlobalPublication(vFed, "pub1", h.HELICS_DATA_TYPE_COMPLEX, "")
+    pubid = h.helicsFederateRegisterGlobalPublication(
+        vFed, "pub1", h.HELICS_DATA_TYPE_COMPLEX, ""
+    )
     subid = h.helicsFederateRegisterSubscription(vFed, "pub1", "")
     h.helicsInputSetDefaultComplex(subid, complex(rDefaultValue, iDefaultValue))
 
@@ -347,18 +359,19 @@ def test_valuefederate_test_complex():
 
     assert complex(rTestValue, iTestValue) == h.helicsInputGetComplex(subid)
 
-    destroyFederate(vFed, fedinfo)
-    destroyBroker(broker)
+    destroy_federate(vFed, fedinfo)
+    destroy_broker(broker)
 
 
 def test_valuefederate_test_integer():
-
-    broker = createBroker()
-    vFed, fedinfo = createValueFederate()
+    broker = create_broker()
+    vFed, fedinfo = create_value_federate()
 
     defaultValue = 1
     testValue = 2
-    pubid = h.helicsFederateRegisterGlobalPublication(vFed, "pub1", h.HELICS_DATA_TYPE_INT, "")
+    pubid = h.helicsFederateRegisterGlobalPublication(
+        vFed, "pub1", h.HELICS_DATA_TYPE_INT, ""
+    )
     subid = h.helicsFederateRegisterSubscription(vFed, "pub1", "")
     h.helicsInputSetDefaultInteger(subid, defaultValue)
 
@@ -383,17 +396,19 @@ def test_valuefederate_test_integer():
     value = h.helicsInputGetInteger(subid)
     assert value == testValue + 1
 
-    destroyFederate(vFed, fedinfo)
-    destroyBroker(broker)
+    destroy_federate(vFed, fedinfo)
+    destroy_broker(broker)
 
 
 def test_valuefederate_test_string():
-    broker = createBroker()
-    vFed, fedinfo = createValueFederate()
+    broker = create_broker()
+    vFed, fedinfo = create_value_federate()
 
     defaultValue = "String1"
     testValue = "String2"
-    pubid = h.helicsFederateRegisterGlobalPublication(vFed, "pub1", h.HELICS_DATA_TYPE_STRING, "")
+    pubid = h.helicsFederateRegisterGlobalPublication(
+        vFed, "pub1", h.HELICS_DATA_TYPE_STRING, ""
+    )
     subid = h.helicsFederateRegisterSubscription(vFed, "pub1", "")
     h.helicsInputSetDefaultString(subid, defaultValue)
 
@@ -410,17 +425,19 @@ def test_valuefederate_test_string():
     value = h.helicsInputGetString(subid)
     assert value == testValue
 
-    destroyFederate(vFed, fedinfo)
-    destroyBroker(broker)
+    destroy_federate(vFed, fedinfo)
+    destroy_broker(broker)
 
 
 def test_valuefederate_test_vectord():
-    broker = createBroker()
-    vFed, fedinfo = createValueFederate()
+    broker = create_broker()
+    vFed, fedinfo = create_value_federate()
 
     defaultValue = [0.0, 1.0, 2.0]
     testValue = [3.0, 4.0, 5.0]
-    pubid = h.helicsFederateRegisterGlobalPublication(vFed, "pub1", h.HELICS_DATA_TYPE_VECTOR, "")
+    pubid = h.helicsFederateRegisterGlobalPublication(
+        vFed, "pub1", h.HELICS_DATA_TYPE_VECTOR, ""
+    )
     subid = h.helicsFederateRegisterSubscription(vFed, "pub1", "")
     h.helicsInputSetDefaultVector(subid, defaultValue)
 
@@ -437,17 +454,19 @@ def test_valuefederate_test_vectord():
 
     assert value == testValue
 
-    destroyFederate(vFed, fedinfo)
-    destroyBroker(broker)
+    destroy_federate(vFed, fedinfo)
+    destroy_broker(broker)
 
 
 def test_valuefederate_test_single_transfer():
-    broker = createBroker()
-    vFed, fedinfo = createValueFederate()
+    broker = create_broker()
+    vFed, fedinfo = create_value_federate()
 
     s = "n2"
 
-    pubid = h.helicsFederateRegisterGlobalPublication(vFed, "pub1", h.HELICS_DATA_TYPE_STRING, "")
+    pubid = h.helicsFederateRegisterGlobalPublication(
+        vFed, "pub1", h.HELICS_DATA_TYPE_STRING, ""
+    )
     subid = h.helicsFederateRegisterSubscription(vFed, "pub1", "")
 
     h.helicsFederateEnterExecutingMode(vFed)
@@ -466,35 +485,53 @@ def test_valuefederate_test_single_transfer():
 
     h.helicsPublicationPublishString(pubid, "string2")
 
-    destroyFederate(vFed, fedinfo)
-    destroyBroker(broker)
+    destroy_federate(vFed, fedinfo)
+    destroy_broker(broker)
 
 
 def test_valuefederate_default_value_tests():
-    broker = createBroker()
-    vFed1, fedinfo = createValueFederate(1, "fed0")
+    broker = create_broker()
+    vFed1, fedinfo = create_value_federate(1, "fed0")
 
-    inp_raw1 = h.helicsFederateRegisterInput(vFed1, "key1", h.HELICS_DATA_TYPE_RAW, "raw")
-    inp_raw2 = h.helicsFederateRegisterInput(vFed1, "key2", h.HELICS_DATA_TYPE_RAW, "raw")
+    inp_raw1 = h.helicsFederateRegisterInput(
+        vFed1, "key1", h.HELICS_DATA_TYPE_RAW, "raw"
+    )
+    inp_raw2 = h.helicsFederateRegisterInput(
+        vFed1, "key2", h.HELICS_DATA_TYPE_RAW, "raw"
+    )
 
-    inp_bool = h.helicsFederateRegisterInput(vFed1, "key3", h.HELICS_DATA_TYPE_BOOLEAN, "")
+    inp_bool = h.helicsFederateRegisterInput(
+        vFed1, "key3", h.HELICS_DATA_TYPE_BOOLEAN, ""
+    )
 
     inp_time = h.helicsFederateRegisterInput(vFed1, "key4", h.HELICS_DATA_TYPE_TIME, "")
 
-    inp_char = h.helicsFederateRegisterInput(vFed1, "key5", h.HELICS_DATA_TYPE_STRING, "")
+    inp_char = h.helicsFederateRegisterInput(
+        vFed1, "key5", h.HELICS_DATA_TYPE_STRING, ""
+    )
 
-    inp_vect = h.helicsFederateRegisterInput(vFed1, "key6", h.HELICS_DATA_TYPE_VECTOR, "V")
+    inp_vect = h.helicsFederateRegisterInput(
+        vFed1, "key6", h.HELICS_DATA_TYPE_VECTOR, "V"
+    )
 
-    inp_double = h.helicsFederateRegisterInput(vFed1, "key7", h.HELICS_DATA_TYPE_DOUBLE, "kW")
+    inp_double = h.helicsFederateRegisterInput(
+        vFed1, "key7", h.HELICS_DATA_TYPE_DOUBLE, "kW"
+    )
 
-    inp_double2 = h.helicsFederateRegisterInput(vFed1, "key8", h.HELICS_DATA_TYPE_DOUBLE, "")
+    inp_double2 = h.helicsFederateRegisterInput(
+        vFed1, "key8", h.HELICS_DATA_TYPE_DOUBLE, ""
+    )
 
-    inp_np = h.helicsFederateRegisterInput(vFed1, "key9", h.HELICS_DATA_TYPE_NAMED_POINT, "")
+    inp_np = h.helicsFederateRegisterInput(
+        vFed1, "key9", h.HELICS_DATA_TYPE_NAMED_POINT, ""
+    )
 
     h.helicsInputSetMinimumChange(inp_double, 1100.0)
     h.helicsInputSetDefaultDouble(inp_double, 10000.0)
 
-    h.helicsInputSetOption(inp_double2, h.HELICS_HANDLE_OPTION_CONNECTION_REQUIRED, True)
+    h.helicsInputSetOption(
+        inp_double2, h.HELICS_HANDLE_OPTION_CONNECTION_REQUIRED, True
+    )
 
     pub = h.helicsFederateRegisterPublication(vFed1, "", h.HELICS_DATA_TYPE_INT, "MW")
     h.helicsPublicationSetOption(pub, h.HELICS_HANDLE_OPTION_CONNECTION_REQUIRED, True)
@@ -522,10 +559,14 @@ def test_valuefederate_default_value_tests():
     assert c2 == "q"
     h.helicsInputGetVector(inp_vect)
 
-    optset = h.helicsInputGetOption(inp_double2, h.HELICS_HANDLE_OPTION_CONNECTION_REQUIRED)
+    optset = h.helicsInputGetOption(
+        inp_double2, h.HELICS_HANDLE_OPTION_CONNECTION_REQUIRED
+    )
     assert optset == 1
 
-    optset = h.helicsPublicationGetOption(pub, h.HELICS_HANDLE_OPTION_CONNECTION_REQUIRED)
+    optset = h.helicsPublicationGetOption(
+        pub, h.HELICS_HANDLE_OPTION_CONNECTION_REQUIRED
+    )
     assert optset == 1
     h.helicsPublicationPublishInteger(pub, 12)
 
@@ -564,16 +605,17 @@ def test_valuefederate_default_value_tests():
 
     h.helicsFederateDisconnect(vFed1)
 
-    destroyFederate(vFed1, fedinfo)
-    destroyBroker(broker)
+    destroy_federate(vFed1, fedinfo)
+    destroy_broker(broker)
 
 
 def test_valuefederate_test_info_filed():
+    broker = create_broker()
+    vFed, fedinfo = create_value_federate(1, "fed0")
 
-    broker = createBroker()
-    vFed, fedinfo = createValueFederate(1, "fed0")
-
-    h.helicsFederateSetFlagOption(vFed, h.HELICS_HANDLE_OPTION_CONNECTION_OPTIONAL, True)
+    h.helicsFederateSetFlagOption(
+        vFed, h.HELICS_HANDLE_OPTION_CONNECTION_OPTIONAL, True
+    )
     # register the publications/subscriptions
 
     subid1 = h.helicsFederateRegisterSubscription(vFed, "sub1", "")
@@ -598,12 +640,11 @@ def test_valuefederate_test_info_filed():
         wait = h.helicsCoreWaitForDisconnect(cr, 500)
     assert wait is True
 
-    destroyFederate(vFed, fedinfo)
-    destroyBroker(broker)
+    destroy_federate(vFed, fedinfo)
+    destroy_broker(broker)
 
 
 def test_valuefederate_test_file_load():
-
     filename = os.path.join(CURRENT_DIRECTORY, "valuefederate.json")
     vFed = h.helicsCreateValueFederateFromConfig(filename)
 
@@ -615,15 +656,16 @@ def test_valuefederate_test_file_load():
 
     h.helicsFederateDisconnect(vFed)
     h.helicsFederateFree(vFed)
-    h.helicsCloseLibrary()
 
 
 def test_valuefederate_test_bytes():
-    broker = createBroker()
-    vFed, fedinfo = createValueFederate()
+    broker = create_broker()
+    vFed, fedinfo = create_value_federate()
     defaultValue = bytes([1, 2, 3, 4, 5])
     testValue = bytes([5, 4, 3, 2, 1, 0, 255, 30, 17, 18, 19])
-    pubid = h.helicsFederateRegisterGlobalPublication(vFed, "pub1", h.HELICS_DATA_TYPE_RAW, "")
+    pubid = h.helicsFederateRegisterGlobalPublication(
+        vFed, "pub1", h.HELICS_DATA_TYPE_RAW, ""
+    )
     subid = h.helicsFederateRegisterSubscription(vFed, "pub1", "")
     h.helicsInputSetDefaultBytes(subid, defaultValue)
 
@@ -640,5 +682,5 @@ def test_valuefederate_test_bytes():
     value = h.helicsInputGetBytes(subid)
     assert value == testValue
 
-    destroyFederate(vFed, fedinfo)
-    destroyBroker(broker)
+    destroy_federate(vFed, fedinfo)
+    destroy_broker(broker)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,17 +1,15 @@
 # -*- coding: utf-8 -*-
-import os
-import sys
-
-CURRENT_DIRECTORY = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
-
-sys.path.append(CURRENT_DIRECTORY)
-sys.path.append(os.path.dirname(CURRENT_DIRECTORY))
-
 import time
 import helics as h
 
 
-def createBroker(number=1):
+def assert_attributes(obj, attributes: dict[str, any]):
+    for key, value in attributes.items():
+        assert hasattr(obj, key), f"{repr(obj)} does not have attribute {key}"
+        assert getattr(obj, key) == value, f"{repr(obj)}.{key} is not {value}"
+
+
+def create_broker(number=1):
     initstring = f"-f {number} --name=mainbroker"
     # @test_throws h.HELICSErrorInvalidArgument broker = h.helicsCreateBroker("mq", "", initstring)
     broker = h.helicsCreateBroker("zmq", "", initstring)
@@ -20,7 +18,7 @@ def createBroker(number=1):
     return broker
 
 
-def setupFederateInfo(name="A Core", number=1, deltat=0.01):
+def setup_federate_info(name="A Core", number=1, deltat=0.01):
     fedinitstring = f"--broker=mainbroker --federates={number}"
 
     # Create Federate Info object that describes the federate properties
@@ -47,26 +45,25 @@ def setupFederateInfo(name="A Core", number=1, deltat=0.01):
     return fedinfo
 
 
-def createValueFederate(federates=1, name="A Federate", deltat=0.01):
-    fedinfo = setupFederateInfo(name, federates, deltat)
+def create_value_federate(federates=1, name="A Federate", deltat=0.01):
+    fedinfo = setup_federate_info(name, federates, deltat)
     vFed = h.helicsCreateValueFederate(f"Test{name}", fedinfo)
     # assert vFed isa h.ValueFederate
     return vFed, fedinfo
 
 
-def createMessageFederate(federates=1, name="A Federate", deltat=0.01):
-    fedinfo = setupFederateInfo(name, federates, deltat)
+def create_message_federate(federates=1, name="A Federate", deltat=0.01):
+    fedinfo = setup_federate_info(name, federates, deltat)
     mFed = h.helicsCreateMessageFederate(f"Test{name}", fedinfo)
     # assert mFed isa h.MessageFederate
     return mFed, fedinfo
 
 
-def destroyBroker(broker):
+def destroy_broker(broker):
     h.helicsBrokerDisconnect(broker)
-    h.helicsCloseLibrary()
 
 
-def destroyFederate(fed, fedinfo, broker=None):
+def destroy_federate(fed, fedinfo, broker=None):
     h.helicsFederateDisconnect(fed)
     _ = h.helicsFederateGetState(fed)
     if broker is not None:
@@ -75,8 +72,4 @@ def destroyFederate(fed, fedinfo, broker=None):
     h.helicsFederateInfoFree(fedinfo)
     h.helicsFederateFree(fed)
     if broker is not None:
-        destroyBroker(broker)
-
-
-destroyValueFederate = destroyFederate
-destroyMessageFederate = destroyFederate
+        destroy_broker(broker)


### PR DESCRIPTION
Replaces all repr testing with two functions:
- assert_attributes which checks attributes in an expected dictionary
- assert_entries which asserts that all elements are contained as entries. This is required for the _InputOptionAccessor for example which contains the status of many flags like `CONNECTION_REQUIRED`.

I'm not 100% with using a helper function since dictionaries are harder to automatically refactor, but using a dictionary allows the possibility of reuse and can be more concise.

I also couldn't help myself and cleaned up a few things in the tests which were a bit strange.

I replaced many of the sys.path.append commands with .utils. This may cause a problem if you have not installed helics using pip install and are still trying to run tests from somewhere other than the root directory. Considering how annoying sys.path.append for any automatic tooling, I consider this specific use case somewhat irrelevant.

- test_inits gets moved to .utils which is much more transparent and is not accessed by pytest
- Changed the other functions in test_inits to be more pythonic.
- Ran a python formatter on the tests. I didn't see any linting parameters, so I just used my own defaults.
- Added a conftest.py to do helicsCloseLibrary. There are few functions which still call close library
  to ensure that files are run. Doing this as an autouse fixture allows us to avoid segfaults on test failures, since it will run regardless of any asserts. TLDR: this clears up any segfaults on failures 🤞 .
