### PR TITLE
Add logging path to cli runner.json

### DIFF
--- a/helics/cli.py
+++ b/helics/cli.py
@@ -282,6 +282,14 @@ def run(path, silent, connect_server, no_log_files, no_kill_on_error):
     if helics_server_available:
         fetch("/runner/file/name", {"name": os.path.basename(path_to_config)})
         fetch("/runner/file/folder", {"folder": os.path.dirname(path_to_config)})
+    
+    # Default to logging in the same location as the config file; this is the 
+    # historical behavior of the cli. If there's a "logging_path" in the runner
+    # JSON, use that path    
+    if "logging_path" in config.keys():
+        logging_path = config["logging_path"]
+    else:
+        logging_path = path
 
     process_list = []
     output_list = []
@@ -293,7 +301,7 @@ def run(path, silent, connect_server, no_log_files, no_kill_on_error):
                 ),
             )
 
-        fname = os.path.abspath(os.path.join(path, "{}.log".format(f["name"])))
+        fname = os.path.abspath(os.path.join(logging_path, "{}.log".format(f["name"])))
         if log is True:
             o = Output(fname, open(fname, "w"))
         else:


### PR DESCRIPTION
Adds the ability to put "logging_path" in the root of the runner.json and specify the location where the log files should be written.