### PR TITLE
Add git archival file for git version info in source tarballs

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,3 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt export-subst


### PR DESCRIPTION
Adds a .git_archival.txt file so source archives (e.g. no git repo info) have the information on version tags/commits needed for setuptools_scm to figure out the correct version number.