### PR TITLE
Use native aarch64 runner for building aarch64 wheels

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       use_qemu:
-        description: 'Use qemu to build linux aarch64, ppc64le & s390x'
+        description: 'Use qemu to build linux, ppc64le & s390x'
         required: false
         default: 'false'
   workflow_run:
@@ -32,11 +32,11 @@ jobs:
             build: "manylinux_"
             artifact_suffix: "manylinux_x86_64"
             use_qemu: false
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04-arm
             arch: "aarch64"
             build: "manylinux_"
             artifact_suffix: "manylinux_aarch64"
-            use_qemu: true
+            use_qemu: false
           - os: windows-2019
             arch: "AMD64"
             build: ""


### PR DESCRIPTION
Try using the newly released Linux ARM runners from GitHub for aarch64 wheel builds instead of QEMU. Build time change: 1hr 7m -> 5m