### PR TITLE
Update CLI runner documentation

### DIFF
--- a/docs/cli-interface.md
+++ b/docs/cli-interface.md
@@ -7,7 +7,7 @@ CLI for running Hierarchical Engine for Large-scale Infrastructure Co-Simulation
 
 ![](https://user-images.githubusercontent.com/1813121/144665647-c95e653b-dbc6-410d-b653-2c7510294a76.png)
 
-### Documentation
+## Quick Examples
 
 ```bash
 helics --help
@@ -30,44 +30,15 @@ Commands:
   server
 ```
 
-```bash
-helics run --help
-```
-
-```
-Usage: helics run [OPTIONS]
-
-  Run HELICS federation
-
-Options:
-  --path PATH                     Path to config.json that describes how to
-                                  run a federation  [required]
-  --silent
-  --no-log-files
-  --no-kill-on-error              Do not kill all federates on error
-  -l, --broker-loglevel, --loglevel TEXT
-                                  Log level for HELICS broker
-  --profile                       Profile flag
-  -w, --web                       Run the web interface on startup
-  --help                          Show this message and exit.
-```
-
-```bash
-$ helics profile-plot --help
-```
-
-```
-Usage: helics profile-plot [OPTIONS]
-
-Options:
-  --path PATH  Path to profile.txt that describes profiling results of a
-               federation  [required]
-  --help       Show this message and exit.
-```
-
-### Usage
+## Usage
 
 ```bash
 helics run --path examples/pi-exchange/runner.json --profile
 helics profile-plot examples/pi-exchange/profile.txt
 ```
+
+::: mkdocs-click
+    :module: helics.cli
+    :command: cli
+    :prog_name: helics
+    :list_subcommands: True

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,3 +47,5 @@ markdown_extensions:
   - pymdownx.tasklist:
       custom_checkbox: True
   - pymdownx.tilde
+  - mkdocs-click
+  - attr_list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ docs = [
   "black",
   "pygments",
   "pymdown-extensions",
+  "mkdocs-click",
 ]
 
 [project.scripts]


### PR DESCRIPTION
- Adds mkdocs-click to the pyproject.toml docs dependencies
- Uses mkdocs-click to display autogenereated `helics` CLI documentation, and removes the old copy-pasted `--help` commands.
- Adds more content to the `helics run` CLI doc-string and argument help strings.

You should be able to see the changes if you do `mkdocs serve` and  go to the CLI interface section. You can also see the updated documentation at `helics run --help`.